### PR TITLE
Rewrite substring logic so that it passes fn-substring-22 and doesn't…

### DIFF
--- a/vendor/xpath-tests/filters
+++ b/vendor/xpath-tests/filters
@@ -1361,7 +1361,6 @@ cbcl-subsequence-012
 cbcl-subsequence-013
 cbcl-subsequence-014
 = fn-substring
-fn-substring-22
 = fn-substring-after
 = fn-substring-before
 = fn-sum


### PR DESCRIPTION
@bartschuller found that if we run the XPath conformance tests in debug mode, we get various overflow errors. One cluster was in fn-substring. This fixes that, and incidentially also fixes the broken fn-substring-22.
