### PR TITLE
Fixed description of how to install xee from source

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,7 @@ Then:
 
 ```
 git clone https://github.com/Paligo/xee.git
-cd xee
-cargo install --path .
+cargo install --path xee/xee
 ```
 
 Note that you need a recent stable version of Rust; `rustup update` should get


### PR DESCRIPTION
When following the sequence of commands to install `xee` as it currently stands, I get an error

```
error: found a virtual manifest at `/home/jofas/usr/xee/Cargo.toml` instead of a package manifest
```

because `--path .` points to the workspace directory, when it should point to the `./xee` directory. I further simplified this by removing the `cd xee`.

I didn't raise an issue for such a small change, hope that's alright.