### PR TITLE
Fix issue running tests on Windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -628,6 +628,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "form_urlencoded"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1196,6 +1205,27 @@ name = "icu_timezone_data"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c588878c508a3e2ace333b3c50296053e6483c6a7541251b546cc59dcd6ced8e"
+
+[[package]]
+name = "idna"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
 
 [[package]]
 name = "indexmap"
@@ -2612,6 +2642,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0976c77def3f1f75c4ef892a292c31c0bbe9e3d0702c63044d7c76db298171a3"
 
 [[package]]
+name = "url"
+version = "2.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+]
+
+[[package]]
 name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3012,6 +3053,7 @@ dependencies = [
  "iri-string",
  "tempfile",
  "thiserror 2.0.12",
+ "url",
  "xee-name",
  "xee-xpath",
  "xee-xpath-load",

--- a/xee-testrunner/Cargo.toml
+++ b/xee-testrunner/Cargo.toml
@@ -28,6 +28,7 @@ globset = "0.4.16"
 chrono = { workspace = true }
 ibig = { workspace = true }
 iri-string = { workspace = true }
+url = "2.5.4"
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml", "glob"] }

--- a/xee-testrunner/src/testset.rs
+++ b/xee-testrunner/src/testset.rs
@@ -37,9 +37,9 @@ impl<E: Environment, R: Runnable<E>> TestSet<E, R> {
     }
 
     pub(crate) fn file_uri(&self) -> IriAbsoluteString {
-        format!("file://{}", self.full_path.to_string_lossy())
-            .try_into()
-            .unwrap()
+        let url_str =
+            url::Url::from_file_path(&self.full_path).expect("Only absolute path is supported");
+        IriAbsoluteString::try_from(format!("{url_str}")).expect("Failed to convert file path URI")
     }
 
     pub(crate) fn run(


### PR DESCRIPTION
I'm not sure whether this is a proper fix or not because it introduces new dependency. However the old code is a hack that doesn't work properly:
1. It doesn't support Windows paths at all, neither casual `C:\filename.txt` nor UNC path `\\?\C:\filepath.txt`
2. It's not correct when dealing with characters that needs escaping.

This PR use `url` crate's ``::from_file_path()` to implement these properly, after this fix i'm able to run tests on Windows.