### PR TITLE
Implement fn:random-number-generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1898,6 +1898,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_xoshiro"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f97cdb2a36ed4183de61b2f824cc45c9f1037f28afe0a322e9fff4c108b5aaa"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2944,6 +2953,8 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "percent-encoding",
+ "rand",
+ "rand_xoshiro",
  "regexml",
  "rust_decimal",
  "rust_decimal_macros",

--- a/vendor/xpath-tests/filters
+++ b/vendor/xpath-tests/filters
@@ -909,9 +909,6 @@ fn-function-lookup-750
 fn-function-lookup-751
 fn-function-lookup-754
 fn-function-lookup-755
-fn-function-lookup-756
-fn-function-lookup-757
-fn-function-lookup-758
 fn-function-lookup-759
 fn-function-lookup-761
 fn-function-lookup-762
@@ -1239,47 +1236,6 @@ parse-xml-fragment-015
 = fn-prefix-from-QName
 fn-prefix-from-qname-8
 = fn-random-number-generator
-fn-random-number-generator-1
-fn-random-number-generator-10
-fn-random-number-generator-11
-fn-random-number-generator-12
-fn-random-number-generator-13
-fn-random-number-generator-14
-fn-random-number-generator-15
-fn-random-number-generator-16
-fn-random-number-generator-17
-fn-random-number-generator-18
-fn-random-number-generator-19
-fn-random-number-generator-2
-fn-random-number-generator-20
-fn-random-number-generator-23
-fn-random-number-generator-24
-fn-random-number-generator-25
-fn-random-number-generator-26
-fn-random-number-generator-27
-fn-random-number-generator-28
-fn-random-number-generator-29
-fn-random-number-generator-3
-fn-random-number-generator-30
-fn-random-number-generator-32
-fn-random-number-generator-33
-fn-random-number-generator-34
-fn-random-number-generator-35
-fn-random-number-generator-36
-fn-random-number-generator-37
-fn-random-number-generator-38
-fn-random-number-generator-39
-fn-random-number-generator-4
-fn-random-number-generator-40
-fn-random-number-generator-41
-fn-random-number-generator-42
-fn-random-number-generator-43
-fn-random-number-generator-44
-fn-random-number-generator-5
-fn-random-number-generator-6
-fn-random-number-generator-7
-fn-random-number-generator-8
-fn-random-number-generator-9
 = fn-remove
 = fn-replace
 = fn-resolve-QName

--- a/xee-interpreter/Cargo.toml
+++ b/xee-interpreter/Cargo.toml
@@ -57,6 +57,8 @@ percent-encoding = "2.3.1"
 json = { workspace = true }
 v_jsonescape = "0.7.8"
 static_assertions = "1.1.0"
+rand = { version = "0.8.5", default-features = false }
+rand_xoshiro = "0.6.0"
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml", "glob"] }

--- a/xee-interpreter/src/context/static_context.rs
+++ b/xee-interpreter/src/context/static_context.rs
@@ -139,4 +139,13 @@ impl StaticContext {
     ) -> Option<function::StaticFunctionId> {
         self.functions.get_by_name(name, arity)
     }
+
+    /// Get an internal static function by name and arity
+    pub fn function_id_by_internal_name(
+        &self,
+        name: &xot::xmlname::OwnedName,
+        arity: u8,
+    ) -> Option<function::StaticFunctionId> {
+        self.functions.get_by_internal_name(name, arity)
+    }
 }

--- a/xee-interpreter/src/function/signature.rs
+++ b/xee-interpreter/src/function/signature.rs
@@ -100,6 +100,14 @@ impl Signature {
                 ),
                 (self.clone(), None),
             ],
+            FunctionKind::AnonymousClosure => vec![(
+                Self {
+                    parameter_types: self.parameter_types[..self.parameter_types.len() - 1]
+                        .to_vec(),
+                    return_type: self.return_type.clone(),
+                },
+                Some(function_kind),
+            )],
         }
     }
 

--- a/xee-interpreter/src/interpreter/program.rs
+++ b/xee-interpreter/src/interpreter/program.rs
@@ -126,7 +126,7 @@ impl<'a, 'b> FunctionInfo<'a, 'b> {
         match self.function {
             function::Function::Static(data) => {
                 let static_function = self.program.static_function(data.id);
-                Some(static_function.name().clone())
+                static_function.name().cloned()
             }
             _ => None,
         }

--- a/xee-interpreter/src/library/numeric.rs
+++ b/xee-interpreter/src/library/numeric.rs
@@ -1,15 +1,23 @@
 // https://www.w3.org/TR/xpath-functions-31/#numeric-functions
+use ahash::random_state::RandomState;
 use ibig::ops::Abs;
 use ibig::IBig;
 use num_traits::Float;
+use rand::prelude::*;
+use rand_xoshiro::SplitMix64;
 
+use xee_name::{Name, FN_NAMESPACE};
 use xee_xpath_macros::xpath_fn;
 
 use crate::atomic::round_atomic;
 use crate::atomic::round_half_to_even_atomic;
 use crate::atomic::Atomic;
+use crate::context;
 use crate::error;
+use crate::function;
 use crate::function::StaticFunctionDescription;
+use crate::interpreter::Interpreter;
+use crate::sequence;
 use crate::wrap_xpath_fn;
 
 #[xpath_fn("fn:abs($arg as xs:numeric?) as xs:numeric?")]
@@ -107,6 +115,85 @@ fn number(arg: Option<Atomic>) -> error::Result<Atomic> {
     }
 }
 
+#[xpath_fn("fn:random-number-generator() as map(xs:string, item())")]
+fn random_number_generator0(context: &context::DynamicContext) -> error::Result<function::Map> {
+    random_number_generator1(context, None)
+}
+
+#[xpath_fn("fn:random-number-generator($seed as xs:anyAtomicType?) as map(xs:string, item())")]
+fn random_number_generator1(
+    context: &context::DynamicContext,
+    seed: Option<Atomic>,
+) -> error::Result<function::Map> {
+    // use a hash function with a fixed seed
+    let random_state = RandomState::with_seeds(0, 0, 0, 0);
+    let seed = if let Some(seed) = seed {
+        random_state.hash_one(seed)
+    } else {
+        random_state.hash_one(context.current_datetime())
+    };
+    rng_object(context, seed)
+}
+
+fn rng_object(context: &context::DynamicContext, seed: u64) -> error::Result<function::Map> {
+    // XPath 3.1 states that all xs:double values in [0.0, 1.0) SHOULD be
+    // equally likely, but a mathematically uniform distribution is clearly
+    // the intent.
+    let number = SplitMix64::seed_from_u64(seed).gen_range(0.0..1.0);
+    let static_context = context.static_context();
+    let next_name = Name::new(
+        "_rng-next".to_string(),
+        FN_NAMESPACE.to_string(),
+        String::new(),
+    );
+    let next_id = static_context
+        .function_id_by_internal_name(&next_name, 0)
+        .unwrap();
+    let next = Interpreter::create_static_closure(context, next_id, || Some(seed.into()))?;
+    let permute_name = Name::new(
+        "_rng-permute".to_string(),
+        FN_NAMESPACE.to_string(),
+        String::new(),
+    );
+    let permute_id = static_context
+        .function_id_by_internal_name(&permute_name, 1)
+        .unwrap();
+    let permute = Interpreter::create_static_closure(context, permute_id, || Some(seed.into()))?;
+    function::Map::new(vec![
+        ("number".into(), number.into()),
+        ("next".into(), sequence::Item::from(next).into()),
+        ("permute".into(), sequence::Item::from(permute).into()),
+    ])
+}
+
+#[xpath_fn(
+    "fn:_rng-next($seed as xs:unsignedLong) as map(xs:string, item())",
+    anonymous_closure
+)]
+fn rng_next(context: &context::DynamicContext, seed: u64) -> error::Result<function::Map> {
+    // this code has the same effect as calling next_u64() on a SplitMix64
+    // generator then extracting its state afterward. See the original
+    // implementation at:
+    // https://github.com/rust-random/rngs/blob/rand_xoshiro-0.6.0/rand_xoshiro/src/splitmix64.rs#L47-L53
+    const PHI: u64 = 0x9e3779b97f4a7c15;
+    rng_object(context, seed.wrapping_add(PHI))
+}
+
+#[xpath_fn(
+    "fn:_rng-permute($arg as item()*, $seed as xs:unsignedLong) as item()*",
+    anonymous_closure
+)]
+fn rng_permute(arg: &sequence::Sequence, seed: u64) -> sequence::Sequence {
+    // don't use the seed directly, since rejection sampling can cause
+    // consecutive seeds in a next() sequence to produce the same shuffle.
+    // Adding a level of indirection breaks up this correlation.
+    // TODO: mix an argument-based hash into the seed for better randomness.
+    let shuffle_seed = SplitMix64::seed_from_u64(seed).next_u64();
+    let mut items = arg.iter().collect::<Vec<_>>();
+    items.shuffle(&mut SplitMix64::seed_from_u64(shuffle_seed));
+    items.into()
+}
+
 pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
     vec![
         wrap_xpath_fn!(abs),
@@ -117,5 +204,9 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
         wrap_xpath_fn!(round_half_to_even1),
         wrap_xpath_fn!(round_half_to_even2),
         wrap_xpath_fn!(number),
+        wrap_xpath_fn!(random_number_generator0),
+        wrap_xpath_fn!(random_number_generator1),
+        wrap_xpath_fn!(rng_next),
+        wrap_xpath_fn!(rng_permute),
     ]
 }

--- a/xee-ir/src/function_compiler.rs
+++ b/xee-ir/src/function_compiler.rs
@@ -403,7 +403,7 @@ impl<'a> FunctionCompiler<'a> {
                 let context_names = context_names.ok_or(Error::XPDY0002.with_span(span))?;
                 self.compile_variable(&context_names.last, span)?
             }
-            Some(FunctionRule::Collation) | None => {}
+            Some(FunctionRule::Collation) | Some(FunctionRule::AnonymousClosure) | None => {}
         }
         self.builder.emit(
             Instruction::StaticClosure(static_function_id.as_u16()),

--- a/xee-xpath-macros/src/parse.rs
+++ b/xee-xpath-macros/src/parse.rs
@@ -21,6 +21,7 @@ mod kw {
     syn::custom_keyword!(position);
     syn::custom_keyword!(size);
     syn::custom_keyword!(collation);
+    syn::custom_keyword!(anonymous_closure);
 }
 
 impl Parse for XPathFnOptions {
@@ -83,6 +84,9 @@ impl Parse for XPathFnOption {
         } else if lookahead.peek(kw::collation) {
             let _eat: kw::collation = input.parse()?;
             XPathFnOption::Kind("collation".to_string())
+        } else if lookahead.peek(kw::anonymous_closure) {
+            let _eat: kw::anonymous_closure = input.parse()?;
+            XPathFnOption::Kind("anonymous_closure".to_string())
         } else if lookahead.peek(LitStr) {
             let string_literal: LitStr = input.parse()?;
             let signature = string_literal.value();


### PR DESCRIPTION
Some implementation notes:

- The `next()` and `permute()` functions are implemented with a new function kind, `anonymous_closure`. These functions go into a separate map in the `StaticFunctions` registry so they won't show up via direct reference or via `fn:function-lookup()`. Their `name()` returns `None`, since it's logically absent. Like `item_last_optional`, they receive `closure_values[0]` as an implicit last argument, to be supplied by `Interpreter::create_static_closure()`.
- When `fn:random-number-generator` is first called, it creates a `u64` seed from the argument (or from the `current_datetime`) using `ahash`. The crate is designed to randomize its results very aggressively on separate runs, so `RandomState::with_seeds(0, 0, 0, 0)` is used to force it to behave deterministically.
- I was somewhat concerned about different `NaN` payloads creating different hashes, but it looks like `ordered-float` [accounts for this](https://docs.rs/ordered-float/5.0.0/src/ordered_float/lib.rs.html#2039-2048) and canonicalizes the payload as it should.
- [`SplitMix64`](https://docs.rs/rand_xoshiro/0.6.0/rand_xoshiro/struct.SplitMix64.html) from `rand_xoshiro` is used as a lightweight PRNG: its total state is no larger than the `u64` seed. Each RNG object stores a copy of the seed in the `next()` and `permute()` closures. Since `SplitMix64` does not offer any simple way to extract its state after calling `next_u64()`, the `next()` function directly inlines its implementation (a `wrapping_add()` with a magic number).
- If an RNG object is used to `permute()` two different sequences with the same length, it will produce the same ordering for both sequences. (Note that since it is deterministic, it should produce the same ordering twice for the *same* sequence.) I considered mixing a hash of the input `Sequence` into the seed value to avoid this, but there is no `Hash` impl for `Sequence`.
- `xee-interpreter` now depends on `rand ^0.8.5` and `rand_xoshiro ^0.6.0`. These are not the latest versions of the crates, since `ibig ^0.3.6` depends on `rand ^0.8.3`, and I didn't want to create duplicate dependencies.