### PR TITLE
Use portable shebang for check script

### DIFF
--- a/check
+++ b/check
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
 
 cargo test
 cargo run --release --bin xee-testrunner -- check vendor/xpath-tests/


### PR DESCRIPTION
You can't currently run ./check out-of-the-box on MacOS because bash isn't in `/usr/bin`. This is likely to also affect lots of other systems.

See https://en.wikipedia.org/wiki/Shebang_(Unix)#Portability