### PR TITLE
Define concat with arity 99

### DIFF
--- a/vendor/xpath-tests/filters
+++ b/vendor/xpath-tests/filters
@@ -834,7 +834,6 @@ millisecs-903
 millisecs-904
 millisecs-905
 = fn-function-arity
-fn-function-arity-016
 = fn-function-lookup
 fn-function-lookup-005
 fn-function-lookup-006
@@ -920,7 +919,6 @@ fn-function-lookup-765
 fn-function-lookup-766b
 fn-function-lookup-812
 = fn-function-name
-fn-function-name-017
 = fn-generate-id
 = fn-has-children
 = fn-head

--- a/xee-interpreter/src/library/string.rs
+++ b/xee-interpreter/src/library/string.rs
@@ -780,7 +780,7 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
         String::new(),
     );
 
-    for arity in 2..MAX_CONCAT_ARITY {
+    for arity in 2..=MAX_CONCAT_ARITY {
         let signature = function::Signature::new(
             vec![Some(arg_type.clone()); arity],
             Some(string_type.clone()),


### PR DESCRIPTION
The vendored test suite expects concat#99 to be defined, but we were previously only defining up to concat#98.