### PR TITLE
Language trait for testrunner

### DIFF
--- a/xee-testrunner/src/environment/core.rs
+++ b/xee-testrunner/src/environment/core.rs
@@ -21,7 +21,7 @@ use super::{
 };
 
 // the abstract environment. Can be an XPath or XSLT environment.
-pub(crate) trait Environment: Sized {
+pub(crate) trait Environment: Sized + std::fmt::Debug {
     // create an empty environment
     fn empty() -> Self;
 

--- a/xee-testrunner/src/filter.rs
+++ b/xee-testrunner/src/filter.rs
@@ -5,13 +5,13 @@ use std::str::FromStr;
 use anyhow::Error;
 use fxhash::{FxHashMap, FxHashSet};
 
-use crate::environment::Environment;
+use crate::language::Language;
 use crate::outcomes::{CatalogOutcomes, TestSetOutcomes};
-use crate::testcase::{Runnable, TestCase};
+use crate::testcase::TestCase;
 use crate::testset::TestSet;
 
-pub(crate) trait TestFilter<E: Environment, R: Runnable<E>> {
-    fn is_included(&self, test_set: &TestSet<E, R>, test_case: &TestCase<E>) -> bool;
+pub(crate) trait TestFilter<L: Language> {
+    fn is_included(&self, test_set: &TestSet<L>, test_case: &TestCase<L>) -> bool;
 }
 
 pub(crate) struct IncludeAllFilter {}
@@ -22,8 +22,8 @@ impl IncludeAllFilter {
     }
 }
 
-impl<E: Environment, R: Runnable<E>> TestFilter<E, R> for IncludeAllFilter {
-    fn is_included(&self, _test_set: &TestSet<E, R>, _test_case: &TestCase<E>) -> bool {
+impl<L: Language> TestFilter<L> for IncludeAllFilter {
+    fn is_included(&self, _test_set: &TestSet<L>, _test_case: &TestCase<L>) -> bool {
         true
     }
 }
@@ -38,8 +38,8 @@ impl NameFilter {
     }
 }
 
-impl<E: Environment, R: Runnable<E>> TestFilter<E, R> for NameFilter {
-    fn is_included(&self, _test_set: &TestSet<E, R>, test_case: &TestCase<E>) -> bool {
+impl<L: Language> TestFilter<L> for NameFilter {
+    fn is_included(&self, _test_set: &TestSet<L>, test_case: &TestCase<L>) -> bool {
         if let Some(name_filter) = &self.name_filter {
             test_case.name.contains(name_filter)
         } else {
@@ -53,8 +53,8 @@ pub(crate) struct ExcludedNamesFilter {
     comments: FxHashMap<String, FxHashMap<String, String>>,
 }
 
-impl<E: Environment, R: Runnable<E>> TestFilter<E, R> for ExcludedNamesFilter {
-    fn is_included(&self, test_set: &TestSet<E, R>, test_case: &TestCase<E>) -> bool {
+impl<L: Language> TestFilter<L> for ExcludedNamesFilter {
+    fn is_included(&self, test_set: &TestSet<L>, test_case: &TestCase<L>) -> bool {
         let test_set_name = &test_set.name;
         let test_case_name = &test_case.name;
         if let Some(excluded_names) = self.names.get(test_set_name) {

--- a/xee-testrunner/src/language.rs
+++ b/xee-testrunner/src/language.rs
@@ -1,0 +1,17 @@
+use crate::{
+    environment::{Environment, XPathEnvironmentSpec},
+    testcase::{Runnable, XPathTestCase},
+};
+
+pub(crate) trait Language: Sized {
+    type Environment: Environment;
+    type Runnable: Runnable<Self>;
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub(crate) struct XPathLanguage {}
+
+impl Language for XPathLanguage {
+    type Environment = XPathEnvironmentSpec;
+    type Runnable = XPathTestCase;
+}

--- a/xee-testrunner/src/lib.rs
+++ b/xee-testrunner/src/lib.rs
@@ -5,6 +5,7 @@ mod environment;
 mod error;
 mod filter;
 mod hashmap;
+mod language;
 mod metadata;
 mod ns;
 mod outcomes;

--- a/xee-testrunner/src/renderer.rs
+++ b/xee-testrunner/src/renderer.rs
@@ -7,19 +7,19 @@ use crossterm::{
 
 use crate::{
     catalog::Catalog,
-    environment::Environment,
-    testcase::{Runnable, TestCase, TestOutcome, UnexpectedError},
+    language::Language,
+    testcase::{TestCase, TestOutcome, UnexpectedError},
     testset::TestSet,
 };
 
-pub(crate) trait Renderer<E: Environment, R: Runnable<E>> {
+pub(crate) trait Renderer<L: Language> {
     fn render_test_set(
         &self,
         stdout: &mut Stdout,
-        catalog: &Catalog<E, R>,
-        test_set: &TestSet<E, R>,
+        catalog: &Catalog<L>,
+        test_set: &TestSet<L>,
     ) -> std::io::Result<()>;
-    fn render_test_case(&self, stdout: &mut Stdout, test_case: &TestCase<E>)
+    fn render_test_case(&self, stdout: &mut Stdout, test_case: &TestCase<L>)
         -> std::io::Result<()>;
     fn render_test_outcome(
         &self,
@@ -29,7 +29,7 @@ pub(crate) trait Renderer<E: Environment, R: Runnable<E>> {
     fn render_test_set_summary(
         &self,
         stdout: &mut Stdout,
-        test_set: &TestSet<E, R>,
+        test_set: &TestSet<L>,
     ) -> std::io::Result<()>;
 }
 
@@ -41,12 +41,12 @@ impl VerboseRenderer {
     }
 }
 
-impl<E: Environment, R: Runnable<E>> Renderer<E, R> for VerboseRenderer {
+impl<L: Language> Renderer<L> for VerboseRenderer {
     fn render_test_set(
         &self,
         _stdout: &mut Stdout,
-        catalog: &Catalog<E, R>,
-        test_set: &TestSet<E, R>,
+        catalog: &Catalog<L>,
+        test_set: &TestSet<L>,
     ) -> std::io::Result<()> {
         println!("{}", test_set.file_path(catalog).display());
         println!("{}", test_set.name);
@@ -59,7 +59,7 @@ impl<E: Environment, R: Runnable<E>> Renderer<E, R> for VerboseRenderer {
     fn render_test_case(
         &self,
         _stdout: &mut Stdout,
-        test_case: &TestCase<E>,
+        test_case: &TestCase<L>,
     ) -> std::io::Result<()> {
         print!("{} ... ", test_case.name);
         Ok(())
@@ -145,7 +145,7 @@ impl<E: Environment, R: Runnable<E>> Renderer<E, R> for VerboseRenderer {
     fn render_test_set_summary(
         &self,
         _stdout: &mut Stdout,
-        _test_set: &TestSet<E, R>,
+        _test_set: &TestSet<L>,
     ) -> std::io::Result<()> {
         println!();
         Ok(())
@@ -160,12 +160,12 @@ impl CharacterRenderer {
     }
 }
 
-impl<E: Environment, R: Runnable<E>> Renderer<E, R> for CharacterRenderer {
+impl<L: Language> Renderer<L> for CharacterRenderer {
     fn render_test_set(
         &self,
         _stdout: &mut Stdout,
-        catalog: &Catalog<E, R>,
-        test_set: &TestSet<E, R>,
+        catalog: &Catalog<L>,
+        test_set: &TestSet<L>,
     ) -> std::io::Result<()> {
         print!("{} ", test_set.file_path(catalog).display());
         Ok(())
@@ -174,7 +174,7 @@ impl<E: Environment, R: Runnable<E>> Renderer<E, R> for CharacterRenderer {
     fn render_test_case(
         &self,
         _stdout: &mut Stdout,
-        _test_case: &TestCase<E>,
+        _test_case: &TestCase<L>,
     ) -> std::io::Result<()> {
         Ok(())
     }
@@ -211,7 +211,7 @@ impl<E: Environment, R: Runnable<E>> Renderer<E, R> for CharacterRenderer {
     fn render_test_set_summary(
         &self,
         _stdout: &mut Stdout,
-        _test_set: &TestSet<E, R>,
+        _test_set: &TestSet<L>,
     ) -> std::io::Result<()> {
         println!();
         Ok(())

--- a/xee-testrunner/src/runcontext.rs
+++ b/xee-testrunner/src/runcontext.rs
@@ -2,9 +2,8 @@ use xee_xpath::Documents;
 
 use crate::{
     dependency::KnownDependencies,
-    environment::Environment,
+    language::Language,
     renderer::{CharacterRenderer, Renderer, VerboseRenderer},
-    testcase::Runnable,
 };
 
 pub(crate) struct RunContext<'a> {
@@ -26,7 +25,7 @@ impl<'a> RunContext<'a> {
         }
     }
 
-    pub(crate) fn renderer<E: Environment, R: Runnable<E>>(&self) -> Box<dyn Renderer<E, R>> {
+    pub(crate) fn renderer<L: Language>(&self) -> Box<dyn Renderer<L>> {
         if self.verbose {
             Box::new(VerboseRenderer::new())
         } else {

--- a/xee-testrunner/src/testcase/xpath.rs
+++ b/xee-testrunner/src/testcase/xpath.rs
@@ -6,7 +6,7 @@ use xee_xpath::{context, Queries, Query};
 use xee_xpath_load::{convert_string, ContextLoadable};
 
 use crate::{
-    catalog::Catalog, environment::XPathEnvironmentSpec, ns::XPATH_TEST_NS, runcontext::RunContext,
+    catalog::Catalog, language::XPathLanguage, ns::XPATH_TEST_NS, runcontext::RunContext,
     testset::TestSet,
 };
 
@@ -18,15 +18,15 @@ use super::{
 
 #[derive(Debug)]
 pub(crate) struct XPathTestCase {
-    pub(crate) test_case: TestCase<XPathEnvironmentSpec>,
+    pub(crate) test_case: TestCase<XPathLanguage>,
     pub(crate) test: String,
 }
 
 impl XPathTestCase {
     fn namespaces<'a>(
         &'a self,
-        catalog: &'a Catalog<XPathEnvironmentSpec, Self>,
-        test_set: &'a TestSet<XPathEnvironmentSpec, Self>,
+        catalog: &'a Catalog<XPathLanguage>,
+        test_set: &'a TestSet<XPathLanguage>,
     ) -> anyhow::Result<Vec<(&'a str, &'a str)>> {
         let environments = self
             .test_case
@@ -41,16 +41,16 @@ impl XPathTestCase {
     }
 }
 
-impl Runnable<XPathEnvironmentSpec> for XPathTestCase {
-    fn test_case(&self) -> &TestCase<XPathEnvironmentSpec> {
+impl Runnable<XPathLanguage> for XPathTestCase {
+    fn test_case(&self) -> &TestCase<XPathLanguage> {
         &self.test_case
     }
 
     fn run(
         &self,
         run_context: &mut RunContext,
-        catalog: &Catalog<XPathEnvironmentSpec, Self>,
-        test_set: &TestSet<XPathEnvironmentSpec, Self>,
+        catalog: &Catalog<XPathLanguage>,
+        test_set: &TestSet<XPathLanguage>,
     ) -> TestOutcome {
         // first construct static context
         let mut static_context_builder = context::StaticContextBuilder::default();


### PR DESCRIPTION
Simplify the types in the test runner by definining a Language trait with associated types.

This makes the generics a lot simpler throughout. We also can now also easily expand language with more information should that be required.