### PR TITLE
Feat random number generator

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ dependencies = [
  "getrandom 0.2.15",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.34",
 ]
 
 [[package]]
@@ -795,7 +795,7 @@ checksum = "d1fcc7f316b2c079dde77564a1360639c1a956a23fa96122732e416cb10717bb"
 dependencies = [
  "cfg-if",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
  "static_assertions",
 ]
@@ -1656,7 +1656,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2c1f9f56e534ac6a9b8a4600bdf0f530fb393b5f393e7b4d03489c3cf0c3f01"
 dependencies = [
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "serde",
 ]
 
@@ -1808,8 +1808,8 @@ dependencies = [
  "bitflags 2.9.0",
  "lazy_static",
  "num-traits",
- "rand",
- "rand_chacha",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
  "rand_xorshift",
  "regex-syntax 0.8.5",
  "rusty-fork",
@@ -1893,9 +1893,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
  "serde",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -1905,7 +1916,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -1919,12 +1940,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_core"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
+dependencies = [
+ "getrandom 0.3.1",
+]
+
+[[package]]
+name = "rand_seeder"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "502927fdfc3c9645d53e0c95bb2d53783b5a15bfeaeeb96f7703c21fbb76841e"
+dependencies = [
+ "rand_core 0.9.3",
+]
+
+[[package]]
 name = "rand_xorshift"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2081,7 +2120,7 @@ dependencies = [
  "borsh",
  "bytes",
  "num-traits",
- "rand",
+ "rand 0.8.5",
  "rkyv",
  "serde",
  "serde_json",
@@ -2985,6 +3024,9 @@ dependencies = [
  "num-traits",
  "ordered-float",
  "percent-encoding",
+ "rand 0.9.0",
+ "rand_chacha 0.9.0",
+ "rand_seeder",
  "regexml",
  "rust_decimal",
  "rust_decimal_macros",
@@ -3285,7 +3327,16 @@ version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae87e3fcd617500e5d106f0380cf7b77f3c6092aae37191433159dda23cfb087"
 dependencies = [
- "zerocopy-derive",
+ "zerocopy-derive 0.7.34",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
@@ -3293,6 +3344,17 @@ name = "zerocopy-derive"
 version = "0.7.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15e934569e47891f7d9411f1a451d947a60e000ab3bd24fbb970f000387d1b3b"
+dependencies = [
+ "proc-macro2 1.0.86",
+ "quote 1.0.40",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
 dependencies = [
  "proc-macro2 1.0.86",
  "quote 1.0.40",

--- a/conformance/fn.md
+++ b/conformance/fn.md
@@ -108,7 +108,7 @@
 - [x] position
 - [x] prefix-from-QName
 - [x] QName
-- [ ] random-number-generator
+- [x] random-number-generator
 - [x] remove
 - [x] replace
 - [x] resolve-QName

--- a/vendor/xpath-tests/filters
+++ b/vendor/xpath-tests/filters
@@ -1237,47 +1237,6 @@ parse-xml-fragment-015
 = fn-prefix-from-QName
 fn-prefix-from-qname-8
 = fn-random-number-generator
-fn-random-number-generator-1
-fn-random-number-generator-10
-fn-random-number-generator-11
-fn-random-number-generator-12
-fn-random-number-generator-13
-fn-random-number-generator-14
-fn-random-number-generator-15
-fn-random-number-generator-16
-fn-random-number-generator-17
-fn-random-number-generator-18
-fn-random-number-generator-19
-fn-random-number-generator-2
-fn-random-number-generator-20
-fn-random-number-generator-23
-fn-random-number-generator-24
-fn-random-number-generator-25
-fn-random-number-generator-26
-fn-random-number-generator-27
-fn-random-number-generator-28
-fn-random-number-generator-29
-fn-random-number-generator-3
-fn-random-number-generator-30
-fn-random-number-generator-32
-fn-random-number-generator-33
-fn-random-number-generator-34
-fn-random-number-generator-35
-fn-random-number-generator-36
-fn-random-number-generator-37
-fn-random-number-generator-38
-fn-random-number-generator-39
-fn-random-number-generator-4
-fn-random-number-generator-40
-fn-random-number-generator-41
-fn-random-number-generator-42
-fn-random-number-generator-43
-fn-random-number-generator-44
-fn-random-number-generator-5
-fn-random-number-generator-6
-fn-random-number-generator-7
-fn-random-number-generator-8
-fn-random-number-generator-9
 = fn-remove
 = fn-replace
 = fn-resolve-QName

--- a/xee-interpreter/Cargo.toml
+++ b/xee-interpreter/Cargo.toml
@@ -57,6 +57,9 @@ percent-encoding = "2.3.1"
 json = { workspace = true }
 v_jsonescape = "0.7.8"
 static_assertions = "1.1.0"
+rand = "0.9.0"
+rand_chacha = "0.9.0"
+rand_seeder = "0.4.0"
 
 [dev-dependencies]
 insta = { workspace = true, features = ["yaml", "glob"] }

--- a/xee-interpreter/src/atomic/atomic_core.rs
+++ b/xee-interpreter/src/atomic/atomic_core.rs
@@ -753,3 +753,27 @@ impl TryFrom<Atomic> for Name {
         }
     }
 }
+
+// binary
+
+impl TryFrom<Atomic> for Rc<[u8]> {
+    type Error = error::Error;
+
+    fn try_from(a: Atomic) -> Result<Self, Self::Error> {
+        match a {
+            Atomic::Binary(_, n) => Ok(n),
+            _ => Err(error::Error::XPTY0004),
+        }
+    }
+}
+
+impl<'a> TryFrom<&'a Atomic> for Rc<[u8]> {
+    type Error = error::Error;
+
+    fn try_from(a: &'a Atomic) -> Result<Self, Self::Error> {
+        match a {
+            Atomic::Binary(_, n) => Ok(Rc::clone(n)),
+            _ => Err(error::Error::XPTY0004),
+        }
+    }
+}

--- a/xee-interpreter/src/context/static_context.rs
+++ b/xee-interpreter/src/context/static_context.rs
@@ -139,4 +139,12 @@ impl StaticContext {
     ) -> Option<function::StaticFunctionId> {
         self.functions.get_by_name(name, arity)
     }
+
+    /// Get a private function by name
+    pub(crate) fn function_id_by_private_name(
+        &self,
+        name: &str,
+    ) -> Option<function::StaticFunctionId> {
+        self.functions.get_by_private_name(name)
+    }
 }

--- a/xee-interpreter/src/function/static_function.rs
+++ b/xee-interpreter/src/function/static_function.rs
@@ -54,8 +54,31 @@ pub(crate) type StaticFunctionType = fn(
     arguments: &[sequence::Sequence],
 ) -> error::Result<sequence::Sequence>;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum StaticFunctionName {
+    PublicName(Name),
+    PrivateName(&'static str),
+}
+
+impl StaticFunctionName {
+    pub fn public_name(&self) -> Option<&Name> {
+        if let Self::PublicName(name) = self {
+            Some(name)
+        } else {
+            None
+        }
+    }
+}
+
+impl From<Name> for StaticFunctionName {
+    fn from(value: Name) -> Self {
+        Self::PublicName(value)
+    }
+}
+
+
 pub(crate) struct StaticFunctionDescription {
-    pub(crate) name: Name,
+    pub(crate) name: StaticFunctionName,
     pub(crate) signature: function::Signature,
     pub(crate) function_kind: Option<FunctionKind>,
     pub(crate) func: StaticFunctionType,
@@ -92,7 +115,25 @@ impl StaticFunctionDescription {
         let name = signature.name.value.clone();
         let signature: function::Signature = signature.into();
         Self {
-            name,
+            name: name.into(),
+            signature,
+            function_kind,
+            func,
+        }
+    }
+
+    pub(crate) fn new_private(
+        func: StaticFunctionType,
+        signature: &str,
+        private_name: &'static str,
+        function_kind: Option<FunctionKind>,
+        namespaces: &Namespaces,
+    ) -> Self {
+        let signature = ast::Signature::parse(signature, namespaces)
+            .expect("Signature parse failed unexpectedly");
+        let signature: function::Signature = signature.into();
+        Self {
+            name: StaticFunctionName::PrivateName(private_name),
             signature,
             function_kind,
             func,
@@ -143,7 +184,7 @@ impl From<FunctionKind> for FunctionRule {
 }
 
 pub struct StaticFunction {
-    name: Name,
+    name: StaticFunctionName,
     signature: function::Signature,
     arity: usize,
     pub function_rule: Option<FunctionRule>,
@@ -163,7 +204,7 @@ impl Debug for StaticFunction {
 impl StaticFunction {
     pub(crate) fn new(
         func: StaticFunctionType,
-        name: Name,
+        name: StaticFunctionName,
         signature: function::Signature,
         function_kind: Option<FunctionKind>,
     ) -> Self {
@@ -228,8 +269,8 @@ impl StaticFunction {
         }
     }
 
-    pub(crate) fn name(&self) -> &Name {
-        &self.name
+    pub(crate) fn name(&self) -> Option<&Name> {
+        self.name.public_name()
     }
 
     pub(crate) fn arity(&self) -> usize {
@@ -241,7 +282,7 @@ impl StaticFunction {
     }
 
     pub fn display_representation(&self) -> String {
-        let name = self.name.full_name();
+        let name = self.name.public_name().map(|f| f.full_name()).unwrap_or("function".into());
         let signature = self.signature.display_representation();
         format!("{}{}", name, signature)
     }
@@ -260,12 +301,14 @@ fn into_sequences(values: &[stack::Value]) -> error::Result<Vec<sequence::Sequen
 #[derive(Debug)]
 pub struct StaticFunctions {
     by_name: HashMap<(Name, u8), function::StaticFunctionId>,
+    by_private_name: HashMap<&'static str, function::StaticFunctionId>,
     by_index: Vec<StaticFunction>,
 }
 
 impl StaticFunctions {
     pub(crate) fn new() -> Self {
         let mut by_name = HashMap::new();
+        let mut by_private_name = HashMap::new();
         let descriptions = static_function_descriptions();
         let mut by_index = Vec::new();
         for description in descriptions {
@@ -273,17 +316,31 @@ impl StaticFunctions {
         }
 
         for (i, static_function) in by_index.iter().enumerate() {
-            by_name.insert(
-                (static_function.name.clone(), static_function.arity as u8),
-                function::StaticFunctionId(i),
-            );
+            match &static_function.name {
+                StaticFunctionName::PublicName(name) => {
+                    by_name.insert(
+                        (name.clone(), static_function.arity as u8),
+                        function::StaticFunctionId(i)
+                    );
+                },
+                StaticFunctionName::PrivateName(name) => {
+                    by_private_name.insert(
+                        *name,
+                        function::StaticFunctionId(i),
+                    );
+                }
+            }
         }
-        Self { by_name, by_index }
+        Self { by_name, by_private_name, by_index }
     }
 
     pub fn get_by_name(&self, name: &Name, arity: u8) -> Option<function::StaticFunctionId> {
         // TODO annoying clone
         self.by_name.get(&(name.clone(), arity)).copied()
+    }
+
+    pub(crate) fn get_by_private_name(&self, name: &str) -> Option<function::StaticFunctionId> {
+        self.by_private_name.get(name).copied()
     }
 
     pub fn get_by_index(&self, static_function_id: function::StaticFunctionId) -> &StaticFunction {

--- a/xee-interpreter/src/interpreter/program.rs
+++ b/xee-interpreter/src/interpreter/program.rs
@@ -121,12 +121,12 @@ impl<'a, 'b> FunctionInfo<'a, 'b> {
 
     /// Return the name of the function.
     ///
-    /// Note that only static functions have names.
+    /// Note that only non-private static functions have names.
     pub fn name(&self) -> Option<Name> {
         match self.function {
             function::Function::Static(data) => {
                 let static_function = self.program.static_function(data.id);
-                Some(static_function.name().clone())
+                static_function.name().cloned()
             }
             _ => None,
         }

--- a/xee-interpreter/src/library/context.rs
+++ b/xee-interpreter/src/library/context.rs
@@ -81,7 +81,7 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
                 "position".to_string(),
                 FN_NAMESPACE.to_string(),
                 String::new(),
-            ),
+            ).into(),
             signature: ast::Signature::parse("fn:position() as xs:integer", &Namespaces::default())
                 .unwrap()
                 .into(),
@@ -89,7 +89,7 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
             func: bound_position,
         },
         StaticFunctionDescription {
-            name: Name::new("last".to_string(), FN_NAMESPACE.to_string(), String::new()),
+            name: Name::new("last".to_string(), FN_NAMESPACE.to_string(), String::new()).into(),
             signature: ast::Signature::parse("fn:last() as xs:integer", &Namespaces::default())
                 .unwrap()
                 .into(),

--- a/xee-interpreter/src/library/mod.rs
+++ b/xee-interpreter/src/library/mod.rs
@@ -22,6 +22,7 @@ mod sequence;
 mod string;
 mod uri;
 mod xs;
+mod rng;
 
 use crate::function::StaticFunctionDescription;
 
@@ -49,5 +50,6 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
     descriptions.extend(parse::static_function_descriptions());
     descriptions.extend(json::static_function_descriptions());
     descriptions.extend(id::static_function_descriptions());
+    descriptions.extend(rng::static_function_descriptions());
     descriptions
 }

--- a/xee-interpreter/src/library/rng.rs
+++ b/xee-interpreter/src/library/rng.rs
@@ -1,0 +1,192 @@
+use crate::stack::Value;
+use crate::{atomic::IntegerType, error, sequence::Item};
+use std::rc::Rc;
+use std::sync::OnceLock;
+use xee_xpath_macros::xpath_fn;
+
+use crate::function::StaticFunctionDescription;
+use crate::wrap_xpath_fn;
+use crate::{
+    atomic::{self, Atomic, BinaryType},
+    context,
+    function::{FunctionKind, Map, StaticFunctionId},
+    interpreter::Interpreter,
+    sequence::{self, Sequence},
+};
+use ordered_float::OrderedFloat;
+use rand::{seq::SliceRandom, Rng};
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha20Rng;
+use rand_seeder::Seeder;
+
+static RNG_NEXT_ID: OnceLock<StaticFunctionId> = OnceLock::new();
+static RNG_PERMUTE_ID: OnceLock<StaticFunctionId> = OnceLock::new();
+const NUMBER_KEY: &str = "number";
+const NEXT_KEY: &str = "next";
+const PERMUTE_KEY: &str = "permute";
+
+trait Length {
+    const LEN: usize;
+}
+
+impl<T, const LENGTH: usize> Length for [T; LENGTH] {
+    const LEN: usize = LENGTH;
+}
+
+fn _random_number_generator(
+    context: &context::DynamicContext,
+    seed: <ChaCha20Rng as SeedableRng>::Seed,
+    mut seed_loc: Option<Rc<[u8]>>,
+    word_pos: u128,
+) -> error::Result<Map> {
+    let mut rng = create_rng(seed, word_pos);
+    let next_id = RNG_NEXT_ID.get_or_init(|| {
+        context
+            .static_context()
+            .function_id_by_private_name(RNG_NEXT_NAME)
+            .unwrap()
+    });
+    let permute_id = RNG_PERMUTE_ID.get_or_init(|| {
+        context
+            .static_context()
+            .function_id_by_private_name(RNG_PERMUTE_NAME)
+            .unwrap()
+    });
+    let number = atomic::Atomic::Double(OrderedFloat(rng.random()));
+    let new_word_pos = rng.get_word_pos();
+
+    let closure_vars: Value = if let Some(seed_loc) = seed_loc.take() {
+        to_rng_args_with_seed(seed_loc, new_word_pos).into()
+    } else {
+        to_rng_args(seed, new_word_pos).into()
+    };
+
+    let next_closure = Interpreter::create_static_closure(context, *next_id, || {
+        Some(closure_vars.clone())
+    })?;
+    let permute_closure = Interpreter::create_static_closure(context, *permute_id, || {
+        Some(closure_vars.clone())
+    })?;
+    return Map::new(vec![
+        (NUMBER_KEY.into(), number.into()),
+        (NEXT_KEY.into(), sequence::Item::from(next_closure).into()),
+        (
+            PERMUTE_KEY.into(),
+            sequence::Item::from(permute_closure).into(),
+        ),
+    ]);
+}
+
+fn create_rng(seed: <ChaCha20Rng as SeedableRng>::Seed, word_pos: u128) -> ChaCha20Rng {
+    let mut rng = ChaCha20Rng::from_seed(seed);
+    rng.set_word_pos(word_pos);
+    rng
+}
+
+#[xpath_fn("fn:random-number-generator($seed as xs:anyAtomicType?) as map(xs:string, item())")]
+fn random_number_generator(
+    context: &context::DynamicContext,
+    seed: Option<atomic::Atomic>,
+) -> error::Result<Map> {
+    let seed = if let Some(seed) = seed {
+        Seeder::from(seed).make_seed()
+    } else {
+        Seeder::from(context.current_datetime()).make_seed()
+    };
+    return _random_number_generator(context, seed, None, 0);
+}
+
+#[xpath_fn("fn:random-number-generator() as map(xs:string, item())")]
+fn random_number_generator_empty(context: &context::DynamicContext) -> error::Result<Map> {
+    _random_number_generator(
+        context,
+        Seeder::from(context.current_datetime()).make_seed(),
+        None,
+        0,
+    )
+}
+
+const RNG_NEXT_NAME: &str = "rng_next";
+macro_rules! rng_next_panic {
+    () => {
+        "Function called with bad context!"
+    };
+}
+
+#[xpath_fn(
+    "fn:function($seed as xs:anyAtomicType*) as map(xs:string, item())",
+    context_last_optional
+)]
+fn random_number_generator_next<'a>(
+    context: &context::DynamicContext,
+    args: impl Iterator<Item = error::Result<Atomic>>,
+) -> error::Result<Map> {
+    let (seed, seed_loc, word_pos) = extract_rng_args_from_context(args)?;
+    _random_number_generator(context, seed, Some(seed_loc), word_pos)
+}
+
+const RNG_PERMUTE_NAME: &str = "rng_permute";
+
+#[xpath_fn(
+    "fn:function($arg as item()*, $seed as xs:anyAtomicType*) as item()*",
+    context_last_optional
+)]
+fn random_number_generator_permute<'a>(
+    sequence: impl Iterator<Item = error::Result<Item>>,
+    args: impl Iterator<Item = error::Result<Atomic>>,
+) -> error::Result<Sequence> {
+    let (seed, _, word_pos) = extract_rng_args_from_context(args)?;
+    let mut rng = create_rng(seed, word_pos);
+    let mut sequence: Vec<Item> = sequence.collect::<Result<_, _>>()?;
+    sequence.shuffle(&mut rng);
+    Ok(Sequence::new(sequence))
+}
+
+fn to_rng_args(seed: <ChaCha20Rng as SeedableRng>::Seed, word_pos: u128) -> Sequence {
+    let seed = seed.to_vec().into();
+    to_rng_args_with_seed(seed, word_pos)
+}
+
+fn to_rng_args_with_seed(seed: Rc<[u8]>, word_pos: u128) -> Sequence {
+    Sequence::new(vec![
+        Atomic::Binary(BinaryType::Hex, seed).into(),
+        Atomic::Integer(IntegerType::Integer, std::rc::Rc::new(word_pos.into())).into(),
+    ])
+}
+
+fn extract_rng_args_from_context(
+    mut args: impl Iterator<Item = error::Result<Atomic>>,
+) -> error::Result<(<ChaCha20Rng as SeedableRng>::Seed, Rc<[u8]>, u128)> {
+    let Atomic::Binary(_, seed) = args.next().expect(rng_next_panic!())? else {
+        panic!(rng_next_panic!())
+    };
+    let Atomic::Integer(_, word_pos) = args.next().expect(rng_next_panic!())? else {
+        panic!(rng_next_panic!())
+    };
+    Ok((
+        seed.as_ref().try_into().expect(rng_next_panic!()),
+        seed,
+        word_pos.as_ref().try_into().expect(rng_next_panic!()),
+    ))
+}
+
+pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
+    vec![
+        wrap_xpath_fn!(random_number_generator),
+        wrap_xpath_fn!(random_number_generator_empty),
+        StaticFunctionDescription::new_private(
+            random_number_generator_next::WRAPPER,
+            random_number_generator_next::SIGNATURE,
+            RNG_NEXT_NAME,
+            FunctionKind::parse(random_number_generator_next::KIND),
+            &xee_name::Namespaces::default(),
+        ),
+        StaticFunctionDescription::new_private(
+            random_number_generator_permute::WRAPPER,
+            random_number_generator_permute::SIGNATURE,
+            RNG_PERMUTE_NAME,
+            FunctionKind::parse(random_number_generator_permute::KIND),
+            &xee_name::Namespaces::default(),
+        ),
+    ]
+}

--- a/xee-interpreter/src/library/string.rs
+++ b/xee-interpreter/src/library/string.rs
@@ -786,7 +786,7 @@ pub(crate) fn static_function_descriptions() -> Vec<StaticFunctionDescription> {
             Some(string_type.clone()),
         );
         r.push(StaticFunctionDescription {
-            name: name.clone(),
+            name: name.clone().into(),
             signature,
             function_kind: None,
             func: concat,

--- a/xee-schema-type/src/xs.rs
+++ b/xee-schema-type/src/xs.rs
@@ -325,8 +325,8 @@ impl Xs {
             GDay => Some(RustInfo::new("crate::atomic::GDay")),
             GMonth => Some(RustInfo::new("crate::atomic::GMonth")),
             Boolean => Some(RustInfo::new("bool")),
-            Base64Binary => Some(RustInfo::as_ref("Vec<u8>")),
-            HexBinary => Some(RustInfo::as_ref("Vec<u8>")),
+            Base64Binary => Some(RustInfo::as_ref("std::rc::Rc<[u8]>")),
+            HexBinary => Some(RustInfo::as_ref("std::rc::Rc<[u8]>")),
             QName => Some(RustInfo::new("xee_xpath_ast::ast::Name")),
             Notation => None,
 


### PR DESCRIPTION
Hi I found your project through your [blogpost](https://blog.startifact.com/posts/xee/) and decided to contribute. I choose implement a missing XPath function (which turned out to be a little more implementation work than I expected, which in hindsight makes sense).

Anyways, this PR contains 2 commits the first adds the ability to add static functions that don't have a name. These functions can be seen as 'private' functions that only the internal implementation can access (and thus return).
The second commit actually implements [`fn:random-number-generator`](https://www.w3.org/TR/xpath-functions-31/#func-random-number-generator) using these nameless static functions for `next` and `permute`. More detailed why and how about each commit is contained in the commit messages.

I made a few implementation chooses especially in the private static function commit, which you may want to make changes to.