### PR TITLE
feat: Adds static default namespaces

### DIFF
--- a/xee-interpreter/src/function/static_function.rs
+++ b/xee-interpreter/src/function/static_function.rs
@@ -71,12 +71,12 @@ pub(crate) struct StaticFunctionDescription {
 macro_rules! wrap_xpath_fn {
     ($function:path) => {{
         use $function as wrapped_function;
-        let namespaces = xee_name::Namespaces::default();
+        let namespaces = &xee_name::DEFAULT_NAMESPACES;
         $crate::function::StaticFunctionDescription::new(
             wrapped_function::WRAPPER,
             wrapped_function::SIGNATURE,
             $crate::function::FunctionKind::parse(wrapped_function::KIND),
-            &namespaces,
+            namespaces,
         )
     }};
 }

--- a/xee-name/src/lib.rs
+++ b/xee-name/src/lib.rs
@@ -5,6 +5,6 @@
 mod namespaces;
 mod variable_names;
 
-pub use namespaces::{NamespaceLookup, Namespaces, FN_NAMESPACE, XS_NAMESPACE};
+pub use namespaces::{NamespaceLookup, Namespaces, DEFAULT_NAMESPACES, FN_NAMESPACE, XS_NAMESPACE};
 pub use variable_names::VariableNames;
 pub use xot::xmlname::OwnedName as Name;

--- a/xee-name/src/namespaces.rs
+++ b/xee-name/src/namespaces.rs
@@ -1,4 +1,5 @@
 use ahash::{HashMap, HashMapExt};
+use std::sync::LazyLock;
 
 /// The XPath FN namespace URI
 pub const FN_NAMESPACE: &str = "http://www.w3.org/2005/xpath-functions";
@@ -15,6 +16,9 @@ const STATIC_NAMESPACES: [(&str, &str); 7] = [
     ("err", "http://www.w3.org/2005/xqt-errors"),
     ("output", "http://www.w3.org/2010/xslt-xquery-serialization"),
 ];
+
+/// Static default namespaces.
+pub static DEFAULT_NAMESPACES: LazyLock<Namespaces> = LazyLock::new(|| Default::default());
 
 /// Declared namespaces.
 #[derive(Debug, Clone)]


### PR DESCRIPTION
This commit adds a static variable in `xee-name` that contains the default namespaces. This is then used in the `wrap_xpath_fn` in `xee-interpreter` so a `HashMap` is not constructed for each static function.

Implements the thing said [here](https://github.com/Paligo/xee/pull/92#issuecomment-2781460509).