### PR TITLE
Use the sequence serialize function in the test runner.

### DIFF
--- a/xee-interpreter/src/sequence/normalization.rs
+++ b/xee-interpreter/src/sequence/normalization.rs
@@ -54,7 +54,7 @@ pub(crate) fn normalize(
                 // we have to clone the node here as
                 // we don't want to mutate the original document
                 // after this, all nodes should be cloned
-                let node = xot.clone_node(node);
+                let node = xot.clone_with_prefixes(node);
                 if matches!(xot.value(node), xot::Value::Document) {
                     for child in xot.children(node) {
                         flattened_nodes.push(child);

--- a/xee-interpreter/src/sequence/serialization.rs
+++ b/xee-interpreter/src/sequence/serialization.rs
@@ -16,27 +16,27 @@ use super::{
 };
 
 pub struct SerializationParameters {
-    pub(crate) allow_duplicate_names: bool,
-    pub(crate) byte_order_mark: bool,
-    pub(crate) cdata_section_elements: Vec<OwnedName>,
-    pub(crate) doctype_public: Option<String>,
-    pub(crate) doctype_system: Option<String>,
-    pub(crate) encoding: String,
-    pub(crate) escape_uri_attributes: bool,
-    pub(crate) html_version: Decimal,
-    pub(crate) include_content_type: bool,
-    pub(crate) indent: bool,
-    pub(crate) item_separator: String,
-    pub(crate) json_node_output_method: QNameOrString,
-    pub(crate) media_type: Option<String>,
-    pub(crate) method: QNameOrString,
-    pub(crate) normalization_form: Option<String>,
-    pub(crate) omit_xml_declaration: bool,
-    pub(crate) standalone: Option<bool>,
-    pub(crate) suppress_indentation: Vec<OwnedName>,
-    pub(crate) undeclare_prefixes: bool,
-    pub(crate) use_character_maps: HashMap<char, String>,
-    pub(crate) version: String,
+    pub allow_duplicate_names: bool,
+    pub byte_order_mark: bool,
+    pub cdata_section_elements: Vec<OwnedName>,
+    pub doctype_public: Option<String>,
+    pub doctype_system: Option<String>,
+    pub encoding: String,
+    pub escape_uri_attributes: bool,
+    pub html_version: Decimal,
+    pub include_content_type: bool,
+    pub indent: bool,
+    pub item_separator: String,
+    pub json_node_output_method: QNameOrString,
+    pub media_type: Option<String>,
+    pub method: QNameOrString,
+    pub normalization_form: Option<String>,
+    pub omit_xml_declaration: bool,
+    pub standalone: Option<bool>,
+    pub suppress_indentation: Vec<OwnedName>,
+    pub undeclare_prefixes: bool,
+    pub use_character_maps: HashMap<char, String>,
+    pub version: String,
 }
 
 impl SerializationParameters {
@@ -183,6 +183,12 @@ impl SerializationParameters {
     }
 }
 
+impl Default for SerializationParameters {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pub(crate) fn serialize_sequence(
     arg: &Sequence,
     parameters: SerializationParameters,
@@ -233,6 +239,7 @@ fn serialize_xml(
         doctype,
         ..Default::default()
     };
+
     Ok(xot.serialize_xml_string(output_parameters, node)?)
 }
 

--- a/xee-testrunner/Cargo.toml
+++ b/xee-testrunner/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://github.com/Paligo/xee"
 [dependencies]
 xee-xpath-load = { path = "../xee-xpath-load", version = "0.1.4" }
 xee-xpath = { path = "../xee-xpath", version = "0.1.4" }
+# the dependency on the xslt compiler should be replaced with xee-xslt dependency
 xee-xslt-compiler = { path = "../xee-xslt-compiler", version = "0.1.5" }
 xee-name = { path = "../xee-name", version = "0.1.4" }
 anyhow = { workspace = true }

--- a/xee-xpath/src/lib.rs
+++ b/xee-xpath/src/lib.rs
@@ -74,5 +74,5 @@ pub use itemable::Itemable;
 pub use queries::Queries;
 pub use query::{Query, Recurse};
 pub use xee_interpreter::atomic::Atomic;
-pub use xee_interpreter::sequence::{Item, Sequence};
+pub use xee_interpreter::sequence::{Item, Sequence, SerializationParameters};
 pub use xee_interpreter::xml::DocumentHandle;


### PR DESCRIPTION
This exposed a bug in serialize where prefixes weren't properly cloned.

Unfortunately it doesn't make any more tests pass at the moment, but it's still more correct and better code reuse and hopefully sets us up for better XSLT serialization behavior in the future.