### PR TITLE
Removed build script from xee

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,16 +245,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "build-data"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eda20fcece9c23f3c3f4c2751a8a5ca9491c05fa7a69920af65953c3b39b7ce4"
-dependencies = [
- "chrono",
- "safe-regex",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -428,26 +418,6 @@ dependencies = [
  "lazy_static",
  "libc",
  "windows-sys 0.52.0",
-]
-
-[[package]]
-name = "const_format"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
-dependencies = [
- "const_format_proc_macros",
-]
-
-[[package]]
-name = "const_format_proc_macros"
-version = "0.2.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
-dependencies = [
- "proc-macro2 1.0.86",
- "quote 1.0.40",
- "unicode-xid 0.2.6",
 ]
 
 [[package]]
@@ -1785,7 +1755,7 @@ version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf3d2011ab5c909338f7887f4fc896d35932e29146c12c8d01da6b22a80ba759"
 dependencies = [
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2188,53 +2158,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
-name = "safe-proc-macro2"
-version = "1.0.67"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd85be67db87168aa3c13fd0da99f48f2ab005dccad5af5626138dc1df20eb6"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "safe-quote"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77e530f7831f3feafcd5f1aae406ac205dd998436b4007c8e80f03eca78a88f7"
-dependencies = [
- "safe-proc-macro2",
-]
-
-[[package]]
-name = "safe-regex"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5194fafa3cb9da89e0cab6dffa1f3fdded586bd6396d12be11b4cae0c7ee45c2"
-dependencies = [
- "safe-regex-macro",
-]
-
-[[package]]
-name = "safe-regex-compiler"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e822ae1e61251bcfd698317c237cf83f7c57161a5dc24ee609a85697f1ed15b3"
-dependencies = [
- "safe-proc-macro2",
- "safe-quote",
-]
-
-[[package]]
-name = "safe-regex-macro"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2768de7e6ef19f59c5fd3c3ac207ef12b68a49f95e3172d67e4a04cfd992ca06"
-dependencies = [
- "safe-proc-macro2",
- "safe-regex-compiler",
-]
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,7 +2343,7 @@ checksum = "9ca4b3b69a77cbe1ffc9e198781b7acb0c7365a883670e8f1c1bc66fba79a5c5"
 dependencies = [
  "proc-macro2 0.4.30",
  "quote 0.6.13",
- "unicode-xid 0.1.0",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -2637,12 +2560,6 @@ name = "unicode-xid"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc72304796d0818e357ead4e000d19c9c174ab23dc11093ac919054d20a6a7fc"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unwind_safe"
@@ -2962,9 +2879,7 @@ dependencies = [
  "ahash 0.8.11",
  "anyhow",
  "ariadne",
- "build-data",
  "clap",
- "const_format",
  "regex",
  "rustyline",
  "xee-interpreter",

--- a/xee/Cargo.toml
+++ b/xee/Cargo.toml
@@ -22,9 +22,5 @@ anyhow.workspace = true
 regex = { workspace = true }
 rustyline = "15.0.0"
 ahash = { workspace = true }
-const_format = "0.2.34"
-
-[build-dependencies]
-build-data = "0"
 
 [dev-dependencies]

--- a/xee/build.rs
+++ b/xee/build.rs
@@ -1,5 +1,0 @@
-fn main() {
-    build_data::set_GIT_COMMIT();
-    build_data::set_SOURCE_TIMESTAMP();
-    build_data::no_debug_rebuilds();
-}

--- a/xee/src/main.rs
+++ b/xee/src/main.rs
@@ -1,24 +1,16 @@
+mod common;
 mod error;
 mod format;
 mod indent;
 mod repl;
 mod repl_cmd;
-mod xslt;
 mod xpath;
-mod common;
+mod xslt;
 
 use clap::{Parser, Subcommand};
-use const_format::formatcp;
-
-pub(crate) const VERSION: &str = formatcp!(
-    "{} ({}, {})",
-    clap::crate_version!(),
-    env!("SOURCE_TIMESTAMP"),
-    env!("GIT_COMMIT")
-);
 
 #[derive(Parser)]
-#[command(author, about,  version = VERSION, long_about)]
+#[command(author, about, version, long_about)]
 struct Cli {
     #[command(subcommand)]
     command: Commands,

--- a/xee/src/main.rs
+++ b/xee/src/main.rs
@@ -11,7 +11,7 @@ use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
 #[command(author, about, version, long_about)]
-struct Cli {
+pub(crate) struct Cli {
     #[command(subcommand)]
     command: Commands,
 }

--- a/xee/src/repl.rs
+++ b/xee/src/repl.rs
@@ -12,7 +12,6 @@ use xee_xpath::{DocumentHandle, Documents, Itemable, Query};
 use crate::{
     error::{render_error, render_parse_error},
     repl_cmd::{ArgumentDefinition, CommandDefinition, CommandDefinitions},
-    VERSION,
 };
 
 #[derive(Debug, Parser)]
@@ -200,7 +199,7 @@ impl Repl {
             ),
         ]);
 
-        println!("Xee XPath REPL {}", VERSION);
+        println!("Xee XPath REPL {}", clap::crate_version!());
         println!("Type !help for more information.");
         let mut rl = rustyline::DefaultEditor::new()?;
         loop {

--- a/xee/src/repl.rs
+++ b/xee/src/repl.rs
@@ -5,13 +5,14 @@ use std::{
 };
 
 use ahash::HashMap;
-use clap::Parser;
+use clap::{CommandFactory, Parser};
 use rustyline::error::ReadlineError;
 use xee_xpath::{DocumentHandle, Documents, Itemable, Query};
 
 use crate::{
     error::{render_error, render_parse_error},
     repl_cmd::{ArgumentDefinition, CommandDefinition, CommandDefinitions},
+    Cli,
 };
 
 #[derive(Debug, Parser)]
@@ -199,7 +200,10 @@ impl Repl {
             ),
         ]);
 
-        println!("Xee XPath REPL {}", clap::crate_version!());
+        println!(
+            "Xee XPath REPL {}",
+            Cli::command().get_version().unwrap_or_default(),
+        );
         println!("Type !help for more information.");
         let mut rl = rustyline::DefaultEditor::new()?;
         loop {


### PR DESCRIPTION
Closes #60 by deleting the build script. This removes commit hash and source timestamp from the version string shown in the CLI and REPL.