### PR TITLE
Readd git date and commit info to version

### DIFF
--- a/xee/build.rs
+++ b/xee/build.rs
@@ -1,0 +1,19 @@
+use std::process::Command;
+
+fn main() {
+    let output = Command::new("git")
+        .args(["log", "-1", "--format=(%cd %h)", "--date=short"])
+        .output();
+
+    match output {
+        Ok(output) => {
+            if let Ok(git_commit) = String::from_utf8(output.stdout) {
+                println!("cargo:rustc-env=GIT_COMMIT={}", git_commit.trim());
+            }
+        }
+        Err(e) => {
+            eprintln!("Error getting git commit: {}", e);
+            println!("cargo:rustc-env=GIT_COMMIT=(- -)");
+        }
+    }
+}

--- a/xee/src/main.rs
+++ b/xee/src/main.rs
@@ -9,8 +9,10 @@ mod xslt;
 
 use clap::{Parser, Subcommand};
 
+pub(crate) const VERSION: &str = concat!(env!("CARGO_PKG_VERSION"), " ", env!("GIT_COMMIT"));
+
 #[derive(Parser)]
-#[command(author, about, version, long_about)]
+#[command(author, about, version=VERSION, long_about)]
 pub(crate) struct Cli {
     #[command(subcommand)]
     command: Commands,


### PR DESCRIPTION
This commit tries to overcome the pitfalls that led to #104 when compiling from source in the absence of a checkout (such as when the code comes from cargo instead of a git clone)

The change just tries to run git log with appropriate flags to get date and short hash if a git repo is available or uses '-' for those fields in other cases.