### PR TITLE
Specify a timezone when running tests instead of taking it from the environment

### DIFF
--- a/xee-testrunner/src/testcase/xpath.rs
+++ b/xee-testrunner/src/testcase/xpath.rs
@@ -146,6 +146,7 @@ impl Runnable<XPathLanguage> for XPathTestCase {
             builder.context_item(context_item);
         }
         builder.variables(variables.clone());
+        builder.current_datetime(chrono::offset::Utc::now().into());
         // TODO: at present this doesn't load up any query results,
         // as those tests are gated to xquery only, but this might change
         // https://github.com/w3c/qt3tests/issues/66

--- a/xee-testrunner/src/testcase/xslt.rs
+++ b/xee-testrunner/src/testcase/xslt.rs
@@ -132,6 +132,7 @@ impl Runnable<XsltLanguage> for XsltTestCase {
         }
         builder.documents(run_context.documents.documents().clone());
         // builder.variables(variables.clone());
+        builder.current_datetime(chrono::offset::Utc::now().into());
         let context = builder.build();
         let runnable = program.runnable(&context);
         let result = runnable.many(run_context.documents.xot_mut());


### PR DESCRIPTION
Fixes xee-testrunner to use UTC time when running XSLT and XPath tests.
On my machine (UTC+3), this fixes the date-013 and date-042 cases from `vendor/xslt-tests/tests/type/date/_date-test-set.xml`.
Partially addresses #69.