### PR TITLE
Implement support for <assert-xml file=".."/> for XSLT tests

### DIFF
--- a/vendor/xslt-tests/filters
+++ b/vendor/xslt-tests/filters
@@ -57,17 +57,13 @@ accessor-005
 accessor-006
 accessor-008
 accessor-010
-accessor-011
 accessor-013
 accessor-014
 accessor-015
 accessor-016
-accessor-017
-accessor-018
 accessor-020
 accessor-021
 accessor-022
-accessor-023
 accessor-024
 accessor-025
 accessor-026
@@ -714,7 +710,6 @@ avt-0901
 avt-1001
 avt-1203
 avt-1205
-avt-1501
 avt-1502
 avt-1701
 avt-2102
@@ -767,7 +762,6 @@ axes-042
 axes-044
 axes-045
 axes-046
-axes-047
 axes-048
 axes-049
 axes-050
@@ -859,7 +853,6 @@ axes-157
 axes-158
 axes-159
 axes-160
-axes-162
 axes-164
 axes-166
 axes-167
@@ -1000,8 +993,6 @@ base-uri-052
 base-uri-053
 = boolean
 boolean-002
-boolean-026
-boolean-027
 boolean-032
 boolean-047
 boolean-048
@@ -1010,9 +1001,6 @@ boolean-069
 boolean-070
 boolean-071
 boolean-072
-boolean-078
-boolean-079
-boolean-080
 boolean-081
 boolean-082
 boolean-083
@@ -1069,8 +1057,6 @@ bug-3001
 bug-3101
 bug-3102
 bug-3201
-bug-3301
-bug-3401
 bug-3501
 bug-3601
 bug-3701
@@ -1149,9 +1135,6 @@ call-template-2001
 call-template-2101
 call-template-2102
 = castable
-castable-001
-castable-002
-castable-003
 castable-005
 castable-006
 castable-007
@@ -2644,7 +2627,6 @@ extension-functions-0105
 extension-functions-0106
 extension-functions-0201
 = for
-for-001
 for-002
 for-004
 = for-each-group
@@ -3710,7 +3692,6 @@ load-xquery-module-003
 load-xquery-module-004
 = lre
 lre-003
-lre-004
 lre-005
 lre-006
 lre-009
@@ -3799,7 +3780,6 @@ match-011
 match-012
 match-013
 match-014
-match-015
 match-016
 match-017
 match-018
@@ -4085,7 +4065,6 @@ math-1004
 math-1005
 math-1101
 math-1201
-math-1301
 math-1401
 math-1501
 math-1502
@@ -4107,8 +4086,6 @@ math-1517
 math-1518
 math-1519
 math-1601
-math-1701
-math-1801
 math-1901
 math-1902
 math-1903
@@ -4673,7 +4650,6 @@ namespace-4005
 namespace-4007
 namespace-4008
 namespace-4009
-namespace-4101
 namespace-4301
 namespace-4302
 namespace-4401
@@ -4684,7 +4660,6 @@ namespace-4901
 namespace-5001
 namespace-5101
 namespace-5201
-namespace-5501
 namespace-5601
 namespace-5602
 namespace-5701
@@ -5804,7 +5779,6 @@ position-6701
 position-6801
 position-6802
 position-6901
-position-7002
 position-7101
 position-7201
 position-7301
@@ -5834,9 +5808,6 @@ predicate-055
 predicate-056
 predicate-057
 = regex
-regex-001
-regex-002
-regex-003
 regex-004
 regex-005
 regex-014
@@ -8172,21 +8143,16 @@ result-document-1411
 result-document-1501
 result-document-1502
 = root
-root-0102
-root-0104
 root-0301
 root-0401
 root-0501
 root-0502
-root-0601
 = select
 select-0201
 select-0202
 select-0301
 select-0302
-select-0401
 select-0501
-select-0601
 select-0701
 select-0801
 select-0802
@@ -10503,7 +10469,6 @@ string-118
 string-119
 string-120
 string-121
-string-122
 string-125
 string-131
 string-133
@@ -11651,26 +11616,12 @@ tunnel-0406
 tunnel-0501
 = type
 type-0102
-type-0103
-type-0104
-type-0105
-type-0106
-type-0107
-type-0108
-type-0109
 type-0110
 type-0111
 type-0112
 type-0113
 type-0114
 type-0115
-type-0116
-type-0117
-type-0118
-type-0119
-type-0120
-type-0121
-type-0122
 type-0123
 type-0124
 type-0125
@@ -11679,7 +11630,6 @@ type-0127
 type-0128
 type-0129
 type-0130
-type-0131
 type-0132
 type-0133
 type-0134
@@ -11719,10 +11669,7 @@ type-0172
 type-0173
 type-0174
 type-0175
-type-0201
-type-0202
 type-0203
-type-0301
 type-0302
 type-0303
 type-0501
@@ -13504,7 +13451,6 @@ variable-1301
 variable-1402
 variable-1501
 variable-1601
-variable-1701
 variable-1801
 variable-1901
 variable-1902


### PR DESCRIPTION
This ends up fixing 54 tests across the board; out of a total of 537 tests that use `<assert-xml file=".."/>`.

Not convinced that's quite the place or way to implement the feature; just getting my feet wet for now :sweat_smile: 
I experimented with making a new `AssertXmlFile` struct which has a reimplementation of `AssertXml::assert_value`, but that causes more code duplication overall. I also played around with making `assert_xml_query` read the file directly, but then I cannot return a `TestOutcome::EnvironmentError` as easily. I also considered making `AssertXml::MatchFile(...)` hold a relative path and not an absolute path to the needed file, however getting the path to the testcases from `assert_value` is hard, given its current signature.