### PR TITLE
Implement support for xsl:iterate

### DIFF
--- a/vendor/xslt-tests/filters
+++ b/vendor/xslt-tests/filters
@@ -3480,8 +3480,6 @@ initial-template-902a
 innermost-001
 innermost-901
 = iterate
-iterate-002
-iterate-003
 iterate-004
 iterate-006
 iterate-007
@@ -3498,7 +3496,6 @@ iterate-017
 iterate-018
 iterate-019
 iterate-020
-iterate-021
 iterate-022
 iterate-023
 iterate-024

--- a/vendor/xslt-tests/filters
+++ b/vendor/xslt-tests/filters
@@ -3480,7 +3480,6 @@ initial-template-902a
 innermost-001
 innermost-901
 = iterate
-iterate-001
 iterate-002
 iterate-003
 iterate-004

--- a/xee-interpreter/src/error.rs
+++ b/xee-interpreter/src/error.rs
@@ -547,6 +547,17 @@ pub enum Error {
     /// precedence, unless it also contains another binding with the same name
     /// and higher import precedence.
     XTSE0630,
+    /// xsl:break or xsl:next-iteration outside of xsl:iterate's tail position
+    ///
+    /// It is a static error if an xsl:break or xsl:next-iteration element
+    /// appears other than in a tail position within the sequence constructor
+    /// forming the body of an xsl:iterate instruction.
+    XTSE3120,
+    /// Both select attribute and sequence attriute present.
+    ///
+    /// It is a static error if the select attribute of xsl:break or
+    /// xsl:on-completion is present and the instruction has children.
+    XTSE3125,
     /// Circularity
     ///
     /// Circularity in global declarations is now allowed.

--- a/xee-ir/src/function_compiler.rs
+++ b/xee-ir/src/function_compiler.rs
@@ -55,6 +55,13 @@ impl<'a> FunctionCompiler<'a> {
             ir::Expr::If(if_) => self.compile_if(if_, span),
             ir::Expr::Map(map) => self.compile_map(map, span),
             ir::Expr::Filter(filter) => self.compile_filter(filter, span),
+            ir::Expr::Iterate(iterate) => self.compile_iterate(iterate, span),
+            ir::Expr::IterateBreak(iterate_break) => {
+                self.compile_iterate_break(iterate_break, span)
+            }
+            ir::Expr::IterateLetNext(iterate_let_next) => {
+                self.compile_iterate_let_next(iterate_let_next, span)
+            }
             ir::Expr::PatternPredicate(pattern_predicate) => {
                 self.compile_pattern_predicate(pattern_predicate, span)
             }
@@ -664,6 +671,88 @@ impl<'a> FunctionCompiler<'a> {
         self.scopes.pop_name();
         self.scopes.pop_name();
         Ok(())
+    }
+
+    fn compile_iterate(
+        &mut self,
+        iterate: &ir::Iterate,
+        span: SourceSpan,
+    ) -> error::SpannedResult<()> {
+        // create new build sequence on build stack
+        self.builder.emit(Instruction::BuildNew, span);
+
+        // Mark the loop as not yet broken
+        self.builder.emit_constant(false.into(), span);
+        self.scopes.push_name(&iterate.loop_name);
+
+        let (loop_start, loop_end) =
+            self.compile_sequence_loop_init(&iterate.var_atom, &iterate.context_names, span)?;
+
+        self.compile_sequence_get_item(&iterate.var_atom, &iterate.context_names, span)?;
+        // name it
+        self.scopes.push_name(&iterate.context_names.item);
+        // execute the iterate expression, placing result on stack
+        self.compile_expr(&iterate.expr)?;
+        self.scopes.pop_name();
+
+        // push result to build
+        self.builder.emit(Instruction::BuildPush, span);
+
+        // clean up the var_name item
+        self.builder.emit(Instruction::Pop, span);
+
+        // Check if we broke out of the loop
+        self.compile_variable(&iterate.loop_name, span)?;
+        let loop_break = self.builder.emit_jump_forward(JumpCondition::True, span);
+
+        self.compile_sequence_loop_iterate(loop_start, &iterate.context_names, span)?;
+
+        self.builder.patch_jump(loop_end);
+
+        // add the on_complete result after the loop is finished
+        if let Some(on_complete) = &iterate.on_complete {
+            self.compile_expr(on_complete)?;
+            self.builder.emit(Instruction::BuildPush, span);
+        }
+
+        self.builder.patch_jump(loop_break);
+
+        // process loop end after break completes
+        self.compile_sequence_loop_end(span);
+        // pop sequence length name & index;
+        self.scopes.pop_name();
+        self.scopes.pop_name();
+
+        // Remove the loop_name variable
+        self.builder.emit(Instruction::Pop, span);
+        self.scopes.pop_name();
+
+        self.builder.emit(Instruction::BuildComplete, span);
+        Ok(())
+    }
+
+    fn compile_iterate_break(
+        &mut self,
+        iterate_break: &ir::IterateBreak,
+        span: SourceSpan,
+    ) -> error::SpannedResult<()> {
+        // Mark the loop as breaking
+        self.builder.emit_constant(true.into(), span);
+        self.compile_variable_set(&iterate_break.loop_name, span)?;
+        // Return the contained expression
+        self.compile_expr(&iterate_break.return_expr)?;
+        Ok(())
+    }
+    fn compile_iterate_let_next(
+        &mut self,
+        _iterate_let_next: &ir::IterateLetNext,
+        _span: SourceSpan,
+    ) -> error::SpannedResult<()> {
+        // TODO Iterate params yet missing..
+        return Err(error::SpannedError {
+            error: Error::Unsupported,
+            span: None,
+        });
     }
 
     fn compile_quantified(

--- a/xee-ir/src/function_compiler.rs
+++ b/xee-ir/src/function_compiler.rs
@@ -681,6 +681,17 @@ impl<'a> FunctionCompiler<'a> {
         // create new build sequence on build stack
         self.builder.emit(Instruction::BuildNew, span);
 
+        // Add all the parameters
+        for param in iterate.params.iter() {
+            self.compile_expr(&param.value)?;
+            if let Some(type_) = &param.type_ {
+                let sequence_type_id = self.builder.add_sequence_type(type_.clone());
+                self.builder
+                    .emit(Instruction::Treat(sequence_type_id as u16), span);
+            }
+            self.scopes.push_name(&param.name);
+        }
+
         // Mark the loop as not yet broken
         self.builder.emit_constant(false.into(), span);
         self.scopes.push_name(&iterate.loop_name);
@@ -726,6 +737,11 @@ impl<'a> FunctionCompiler<'a> {
         // Remove the loop_name variable
         self.builder.emit(Instruction::Pop, span);
         self.scopes.pop_name();
+        // Remove all the param variables
+        for _param in iterate.params.iter() {
+            self.builder.emit(Instruction::Pop, span);
+            self.scopes.pop_name();
+        }
 
         self.builder.emit(Instruction::BuildComplete, span);
         Ok(())
@@ -743,16 +759,29 @@ impl<'a> FunctionCompiler<'a> {
         self.compile_expr(&iterate_break.return_expr)?;
         Ok(())
     }
+
     fn compile_iterate_let_next(
         &mut self,
-        _iterate_let_next: &ir::IterateLetNext,
-        _span: SourceSpan,
+        iterate_let_next: &ir::IterateLetNext,
+        span: SourceSpan,
     ) -> error::SpannedResult<()> {
-        // TODO Iterate params yet missing..
-        return Err(error::SpannedError {
-            error: Error::Unsupported,
-            span: None,
-        });
+        // First, calculate all parameter values and put them on the stack
+        for param in iterate_let_next.params.iter() {
+            self.compile_expr(&param.value)?;
+            if let Some(type_) = &param.type_ {
+                let sequence_type_id = self.builder.add_sequence_type(type_.clone());
+                self.builder
+                    .emit(Instruction::Treat(sequence_type_id as u16), span);
+            }
+        }
+        // Then, store them back into the variables (in reverse, so they match up)
+        for param in iterate_let_next.params.iter().rev() {
+            self.compile_variable_set(&param.name, span)?;
+        }
+        // Finally, emit a value as the result of IterateLetNext (typ. an empty sequence)
+        // self.builder.emit_constant(sequence::Sequence::default(), span);
+        self.compile_expr(&iterate_let_next.return_expr)?;
+        Ok(())
     }
 
     fn compile_quantified(

--- a/xee-ir/src/ir.rs
+++ b/xee-ir/src/ir.rs
@@ -177,6 +177,7 @@ pub struct Filter {
 pub struct IterateParam {
     pub name: Name,
     pub value: Box<ExprS>,
+    pub type_: Option<SequenceType>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -184,7 +185,7 @@ pub struct Iterate {
     pub context_names: ContextNames,
     pub loop_name: Name,
     pub var_atom: AtomS,
-    // pub params: Vec<IterateParam>,
+    pub params: Vec<IterateParam>,
     pub expr: Box<ExprS>,
     pub on_complete: Option<Box<ExprS>>,
 }
@@ -197,7 +198,7 @@ pub struct IterateBreak {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IterateLetNext {
-    pub param: IterateParam,
+    pub params: Vec<IterateParam>,
     pub return_expr: Box<ExprS>,
 }
 

--- a/xee-ir/src/ir.rs
+++ b/xee-ir/src/ir.rs
@@ -34,6 +34,9 @@ pub enum Expr {
     Deduplicate(Box<ExprS>),
     Map(Map),
     Filter(Filter),
+    Iterate(Iterate),
+    IterateBreak(IterateBreak),
+    IterateLetNext(IterateLetNext),
     PatternPredicate(PatternPredicate),
     Quantified(Quantified),
     Cast(Cast),
@@ -167,6 +170,34 @@ pub struct Map {
 pub struct Filter {
     pub context_names: ContextNames,
     pub var_atom: AtomS,
+    pub return_expr: Box<ExprS>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterateParam {
+    pub name: Name,
+    pub value: Box<ExprS>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Iterate {
+    pub context_names: ContextNames,
+    pub loop_name: Name,
+    pub var_atom: AtomS,
+    // pub params: Vec<IterateParam>,
+    pub expr: Box<ExprS>,
+    pub on_complete: Option<Box<ExprS>>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterateBreak {
+    pub loop_name: Name,
+    pub return_expr: Box<ExprS>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct IterateLetNext {
+    pub param: IterateParam,
     pub return_expr: Box<ExprS>,
 }
 

--- a/xee-xslt-ast/src/ast_core.rs
+++ b/xee-xslt-ast/src/ast_core.rs
@@ -1147,6 +1147,16 @@ pub struct OnCompletion {
     pub span: Span,
 }
 
+impl SelectOrSequenceConstructor for OnCompletion {
+    fn select(&self) -> Option<&Expression> {
+        self.select.as_ref()
+    }
+
+    fn sequence_constructor(&self) -> &SequenceConstructor {
+        &self.sequence_constructor
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct OnEmpty {
@@ -1354,6 +1364,16 @@ pub struct Param {
     pub sequence_constructor: SequenceConstructor,
 
     pub span: Span,
+}
+
+impl SelectOrSequenceConstructor for Param {
+    fn select(&self) -> Option<&Expression> {
+        self.select.as_ref()
+    }
+
+    fn sequence_constructor(&self) -> &SequenceConstructor {
+        &self.sequence_constructor
+    }
 }
 
 impl From<Param> for OverrideContent {
@@ -1714,6 +1734,16 @@ pub struct WithParam {
     pub sequence_constructor: SequenceConstructor,
 
     pub span: Span,
+}
+
+impl SelectOrSequenceConstructor for WithParam {
+    fn select(&self) -> Option<&Expression> {
+        self.select.as_ref()
+    }
+
+    fn sequence_constructor(&self) -> &SequenceConstructor {
+        &self.sequence_constructor
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/xee-xslt-ast/src/ast_core.rs
+++ b/xee-xslt-ast/src/ast_core.rs
@@ -413,6 +413,16 @@ impl From<Break> for SequenceConstructorItem {
     }
 }
 
+impl SelectOrSequenceConstructor for Break {
+    fn select(&self) -> Option<&Expression> {
+        self.select.as_ref()
+    }
+
+    fn sequence_constructor(&self) -> &SequenceConstructor {
+        &self.sequence_constructor
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct CallTemplate {
@@ -821,6 +831,12 @@ pub struct Iterate {
     pub params: Vec<Param>,
     pub on_completion: Option<OnCompletion>,
     pub sequence_constructor: SequenceConstructor,
+}
+
+impl From<Iterate> for SequenceConstructorItem {
+    fn from(i: Iterate) -> Self {
+        SequenceConstructorInstruction::Iterate(Box::new(i)).into()
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/xee-xslt-ast/src/names.rs
+++ b/xee-xslt-ast/src/names.rs
@@ -67,6 +67,9 @@ impl SequenceConstructorName {
             }
             SequenceConstructorName::Fork => ast::Fork::parse_sequence_constructor_item(attributes),
             SequenceConstructorName::If => ast::If::parse_sequence_constructor_item(attributes),
+            SequenceConstructorName::Iterate => {
+                ast::Iterate::parse_sequence_constructor_item(attributes)
+            }
             SequenceConstructorName::Map => ast::Map::parse_sequence_constructor_item(attributes),
             SequenceConstructorName::MapEntry => {
                 ast::MapEntry::parse_sequence_constructor_item(attributes)

--- a/xee-xslt-compiler/src/ast_ir.rs
+++ b/xee-xslt-compiler/src/ast_ir.rs
@@ -644,19 +644,26 @@ impl<'a> IrConverter<'a> {
     fn iterate(&mut self, iterate: &ast::Iterate) -> error::SpannedResult<Bindings> {
         let (var_atom, bindings) = self.expression(&iterate.select)?.atom_bindings();
 
-        if !iterate.params.is_empty() {
-            return Err(error::SpannedError {
-                error: error::Error::Unsupported,
-                span: None,
-            }); // TODO: span
-        }
+        let params = iterate
+            .params
+            .iter()
+            .map(|param| -> error::SpannedResult<ir::IterateParam> {
+                let param_bindings = self.select_or_sequence_constructor(param)?;
+                let name = self.variables.new_var_name(&param.name);
+                Ok(ir::IterateParam {
+                    name,
+                    value: Box::new(param_bindings.expr()),
+                    type_: param.as_.clone(),
+                })
+            })
+            .collect::<error::SpannedResult<Vec<_>>>()?;
 
         let (context_names, loop_name) = self.variables.push_iterate_context();
         let return_bindings = self.sequence_constructor(&iterate.sequence_constructor)?;
         let on_complete_bindings = iterate
             .on_completion
             .as_ref()
-            .map(|oc| self.on_completion(oc))
+            .map(|oc| self.select_or_sequence_constructor(oc))
             .transpose()?;
         self.variables.pop_context();
 
@@ -664,31 +671,12 @@ impl<'a> IrConverter<'a> {
             context_names,
             loop_name,
             var_atom,
+            params,
             expr: Box::new(return_bindings.expr()),
             on_complete: on_complete_bindings.map(|x| Box::new(x.expr())),
         });
 
         Ok(bindings.bind_expr_no_span(&mut self.variables, expr))
-    }
-
-    fn on_completion(
-        &mut self,
-        on_completion: &ast::OnCompletion,
-    ) -> error::SpannedResult<Bindings> {
-        if let Some(select) = &on_completion.select {
-            if !on_completion.sequence_constructor.is_empty() {
-                return Err(error::SpannedError {
-                    error: error::Error::XTSE3125,
-                    span: None,
-                }); // TODO: span
-            }
-            let bindings = self.expression(select)?;
-            Ok(bindings)
-        } else {
-            let return_bindings = self.sequence_constructor(&on_completion.sequence_constructor)?;
-
-            Ok(return_bindings)
-        }
     }
 
     fn break_(&mut self, break_: &ast::Break) -> error::SpannedResult<Bindings> {
@@ -712,18 +700,30 @@ impl<'a> IrConverter<'a> {
         &mut self,
         next_iteration: &ast::NextIteration,
     ) -> error::SpannedResult<Bindings> {
-        if !next_iteration.with_params.is_empty() {
-            return Err(error::SpannedError {
-                error: error::Error::Unsupported,
-                span: None,
-            }); // TODO: Iterate params unsupported
-        }
+        let params = next_iteration
+            .with_params
+            .iter()
+            .map(|param| {
+                let value_bind = self.select_or_sequence_constructor(param)?;
+                Ok(ir::IterateParam {
+                    name: self.variables.new_var_name(&param.name),
+                    value: Box::new(value_bind.expr()),
+                    type_: param.as_.clone(),
+                })
+            })
+            .collect::<error::SpannedResult<Vec<_>>>()?;
 
         let empty_sequence = self.empty_sequence();
-        Ok(Bindings::new(
+        let return_expr = Bindings::new(
             self.variables
                 .new_binding(empty_sequence.value, empty_sequence.span),
-        ))
+        );
+        let let_next = ir::Expr::IterateLetNext(ir::IterateLetNext {
+            params,
+            return_expr: Box::new(return_expr.expr()),
+        });
+        let result = return_expr.bind_expr_no_span(&mut self.variables, let_next);
+        Ok(result)
     }
 
     fn copy(&mut self, copy: &ast::Copy) -> error::SpannedResult<Bindings> {

--- a/xee-xslt-compiler/src/ast_ir.rs
+++ b/xee-xslt-compiler/src/ast_ir.rs
@@ -284,6 +284,9 @@ impl<'a> IrConverter<'a> {
             If(if_) => self.if_(if_),
             Choose(choose) => self.choose(choose),
             ForEach(for_each) => self.for_each(for_each),
+            Iterate(iterate) => self.iterate(iterate),
+            NextIteration(next_iteration) => self.next_iteration(next_iteration),
+            Break(break_) => self.break_(break_),
             Copy(copy) => self.copy(copy),
             CopyOf(copy_of) => self.copy_of(copy_of),
             Sequence(sequence) => self.sequence(sequence),
@@ -636,6 +639,91 @@ impl<'a> IrConverter<'a> {
         });
 
         Ok(bindings.bind_expr_no_span(&mut self.variables, expr))
+    }
+
+    fn iterate(&mut self, iterate: &ast::Iterate) -> error::SpannedResult<Bindings> {
+        let (var_atom, bindings) = self.expression(&iterate.select)?.atom_bindings();
+
+        if !iterate.params.is_empty() {
+            return Err(error::SpannedError {
+                error: error::Error::Unsupported,
+                span: None,
+            }); // TODO: span
+        }
+
+        let (context_names, loop_name) = self.variables.push_iterate_context();
+        let return_bindings = self.sequence_constructor(&iterate.sequence_constructor)?;
+        let on_complete_bindings = iterate
+            .on_completion
+            .as_ref()
+            .map(|oc| self.on_completion(oc))
+            .transpose()?;
+        self.variables.pop_context();
+
+        let expr = ir::Expr::Iterate(ir::Iterate {
+            context_names,
+            loop_name,
+            var_atom,
+            expr: Box::new(return_bindings.expr()),
+            on_complete: on_complete_bindings.map(|x| Box::new(x.expr())),
+        });
+
+        Ok(bindings.bind_expr_no_span(&mut self.variables, expr))
+    }
+
+    fn on_completion(
+        &mut self,
+        on_completion: &ast::OnCompletion,
+    ) -> error::SpannedResult<Bindings> {
+        if let Some(select) = &on_completion.select {
+            if !on_completion.sequence_constructor.is_empty() {
+                return Err(error::SpannedError {
+                    error: error::Error::XTSE3125,
+                    span: None,
+                }); // TODO: span
+            }
+            let bindings = self.expression(select)?;
+            Ok(bindings)
+        } else {
+            let return_bindings = self.sequence_constructor(&on_completion.sequence_constructor)?;
+
+            Ok(return_bindings)
+        }
+    }
+
+    fn break_(&mut self, break_: &ast::Break) -> error::SpannedResult<Bindings> {
+        let loop_name = self
+            .variables
+            .current_iterate_loop_name()
+            .ok_or(error::SpannedError {
+                error: error::Error::XTSE3120,
+                span: None,
+            })?;
+
+        let bindings = self.select_or_sequence_constructor(break_)?;
+        let expr = ir::Expr::IterateBreak(ir::IterateBreak {
+            loop_name,
+            return_expr: Box::new(bindings.expr()),
+        });
+        Ok(bindings.bind_expr_no_span(&mut self.variables, expr))
+    }
+
+    fn next_iteration(
+        &mut self,
+        next_iteration: &ast::NextIteration,
+    ) -> error::SpannedResult<Bindings> {
+        if !next_iteration.with_params.is_empty() {
+            return Err(error::SpannedError {
+                error: error::Error::Unsupported,
+                span: None,
+            }); // TODO: Iterate params unsupported
+        }
+
+        let empty_sequence = self.empty_sequence();
+        Ok(Bindings::new(
+            self.variables
+                .new_binding(empty_sequence.value, empty_sequence.span),
+        ))
     }
 
     fn copy(&mut self, copy: &ast::Copy) -> error::SpannedResult<Bindings> {

--- a/xee-xslt-compiler/tests/test_xslt.rs
+++ b/xee-xslt-compiler/tests/test_xslt.rs
@@ -1211,3 +1211,22 @@ fn test_basic_iterate_if_break() {
     .unwrap();
     assert_eq!(xml(&xot, output), "<o><baz/><baz/>exit at 2 of 3</o>");
 }
+#[test]
+fn test_basic_iterate_params() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc><foo/><foo/><foo/></doc>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:template match="/">
+    <o><xsl:iterate select="doc/foo"><xsl:param name="a" select="1"/><baz><xsl:value-of select="$a"/></baz><xsl:next-iteration><xsl:with-param name="a" select="$a * 2"/></xsl:next-iteration></xsl:iterate></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(
+        xml(&xot, output),
+        "<o><baz>1</baz><baz>2</baz><baz>4</baz></o>"
+    );
+}

--- a/xee-xslt-compiler/tests/test_xslt.rs
+++ b/xee-xslt-compiler/tests/test_xslt.rs
@@ -1143,3 +1143,71 @@ fn test_generate_text_node() {
 
     assert_eq!(xml(&xot, output), r#"<out>test</out>"#);
 }
+
+#[test]
+fn test_basic_iterate() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc><foo/><foo/><foo/></doc>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:template match="/">
+    <o><xsl:iterate select="doc/foo"><bar/></xsl:iterate></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o><bar/><bar/><bar/></o>");
+}
+
+#[test]
+fn test_basic_iterate_on_complete() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc><foo/><foo/><foo/></doc>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:template match="/">
+    <o><xsl:iterate select="doc/foo"><xsl:on-completion><bar/></xsl:on-completion><baz/></xsl:iterate></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o><baz/><baz/><baz/><bar/></o>");
+}
+
+#[test]
+fn test_basic_iterate_on_complete_break() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc><foo/><foo/><foo/></doc>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:template match="/">
+    <o><xsl:iterate select="doc/foo"><xsl:on-completion><bar/></xsl:on-completion><xsl:break/></xsl:iterate></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o/>");
+}
+
+#[test]
+fn test_basic_iterate_if_break() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc><foo/><foo><x/></foo><foo/></doc>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:template match="/">
+    <o><xsl:iterate select="doc/foo"><baz/><xsl:if test="x"><xsl:break select="'exit at ' || position() || ' of ' || last()"/></xsl:if></xsl:iterate></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o><baz/><baz/>exit at 2 of 3</o>");
+}


### PR DESCRIPTION
So... `xsl:iterate` is a bit of a weird one.  
Within XSL's functional language, it fits as a tail-recursive function which produces the rest of the elements at that place in the template.
Here's a possible example:
```xml
<xsl:iterate select="/foo">
  <xsl:param name="n" select="0"/>
  <xsl:value-of select="$n"/>
  <xsl:choose> <!-- tail-position choose -->
    <xsl:when test="n = 4">
      <xsl:break/> <!-- tail early return -->
    </xsl:when>
    <xsl:otherwise>
      Text
      <xsl:next-iteration> <!-- tail recursive call -->
        <xsl:with-param name="n" select="$n + 1"/>
      </xsl:next-iteration>
    </xsl:otherwise>
  </xsl:choose>
</xsl:iterate>
```

However, translating that to Xee's functional IR turns out to be tricky:

* Xee's IR encodes appending elements using its special comma operator. As such, neither the `xsl:next-iteration` nor the `xsl:choose` are really in "tail position" (just like `1 + x()` is not a tail-call); instead we have something like:

```
ir::Binary {
  op: Comma,
  left: <..everything before xsl:choose..>,
  right: ir::If {
    <...>
    else_: ir::Binary {
      op: Comma,
      left: <..everything before xsl:next-iteration..>,
      right: <tail-position xsl:next-iteration>
    }
  }
}
```

* We could presumably place the next-iteration in tail position near the root of the IR tree, outside of any binary operators (yet still inside `ir::If`-s and `ir::Let`-s); but that's gnarly, since we would have to turn any comma operators containing xsl:choose-s and similar conditionals along the way "inside-out" to get them out of the tail position.
* We could, presumably, make it so that some form of tail call optimization in the IR-to-bytecode compiler understands comma operators, so that we can still preserve the idea that `xsl:iterate` is a tail-recursive function. That feels even less tractable than the previous point...

So, instead of all of that tail-recursive nastiness ( :innocent: ), this PR ends up implementing `xsl:next-iteration` and `xsl:break` as sort-of functional effects scoped by the `xsl:iterate` loop: they imperatively set values on the `xsl:iterate` loop that control the next iteration of the loop, however those imperative side-effects cannot be observed by the subsequent code in the current iteration of the loop. Within the IR, `IterateBreak` and `IterateLetNext` act as sort-of decorators: they cause a change to the execution of the subsequent iteration, but otherwise pass expression results unchanged.

Hope that description helps explain my line of thought in implementing what I did :blush: 