### PR TITLE
Add optional sync feature to allow sharing DocumentsRef.

### DIFF
--- a/xee-interpreter/Cargo.toml
+++ b/xee-interpreter/Cargo.toml
@@ -23,6 +23,7 @@ serde = [
     "chumsky/serde",
     "xot/serde",
 ]
+sync = []
 
 [dependencies]
 xee-xpath-ast = { path = "../xee-xpath-ast", version = "0.1.4" }

--- a/xee-interpreter/src/context/borrow.rs
+++ b/xee-interpreter/src/context/borrow.rs
@@ -1,0 +1,36 @@
+use std::{cell::{Ref, RefCell, RefMut}, sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard}};
+
+
+pub trait BorrowWith<'a> {
+    type Read: 'a;
+    type Write: 'a;
+
+    fn borrow(&'a self) -> Self::Read;
+    fn borrow_mut(&'a self) -> Self::Write;
+}
+
+impl<'a, T: 'a> BorrowWith<'a> for RefCell<T> {
+    type Read = Ref<'a, T>;
+    type Write = RefMut<'a, T>;
+
+    fn borrow(&'a self) -> Self::Read {
+        self.borrow()
+    }
+
+    fn borrow_mut(&'a self) -> Self::Write {
+        self.borrow_mut()
+    }
+}
+
+impl<'a, T: 'a> BorrowWith<'a> for Arc<RwLock<T>> {
+    type Read = RwLockReadGuard<'a, T>;
+    type Write = RwLockWriteGuard<'a, T>;
+
+    fn borrow(&'a self) -> Self::Read {
+        self.read().unwrap()
+    }
+
+    fn borrow_mut(&'a self) -> Self::Write {
+        self.write().unwrap()
+    }
+}

--- a/xee-interpreter/src/context/dynamic_context_builder.rs
+++ b/xee-interpreter/src/context/dynamic_context_builder.rs
@@ -1,8 +1,13 @@
-use std::{cell::RefCell, ops::Deref, rc::Rc};
+#[cfg(not(feature = "sync"))]
+use std::cell::RefMut;
+#[cfg(feature = "sync")]
+use std::sync::{RwLockReadGuard, RwLockWriteGuard};
+use std::{cell::{Ref, RefCell}, ops::Deref, rc::Rc, sync::{Arc, RwLock}};
 
 use ahash::{HashMap, HashMapExt};
 use iri_string::types::{IriStr, IriString};
 
+use crate::context::BorrowWith;
 use crate::{interpreter, sequence, xml};
 
 use super::{DynamicContext, Variables};
@@ -30,11 +35,20 @@ pub struct DynamicContextBuilder<'a> {
 
 /// A shallow wrapper around a collection of XML documents
 /// [`xml::Documents`]
+#[cfg(not(feature = "sync"))]
 #[derive(Debug, Clone)]
 pub struct DocumentsRef(Rc<RefCell<xml::Documents>>);
 
+#[cfg(feature = "sync")]
+#[derive(Debug, Clone)]
+pub struct DocumentsRef(Arc<RwLock<xml::Documents>>);
+
 impl Deref for DocumentsRef {
+    #[cfg(not(feature = "sync"))]
     type Target = RefCell<xml::Documents>;
+
+    #[cfg(feature = "sync")]
+    type Target = RwLock<xml::Documents>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
@@ -42,14 +56,54 @@ impl Deref for DocumentsRef {
 }
 
 impl From<xml::Documents> for DocumentsRef {
+    #[cfg(not(feature = "sync"))]
     fn from(documents: xml::Documents) -> Self {
         Self(Rc::new(RefCell::new(documents)))
+    }
+    
+    #[cfg(feature = "sync")]
+    fn from(documents: xml::Documents) -> Self {
+
+        Self(Arc::new(RwLock::new(documents)))
     }
 }
 
 impl DocumentsRef {
+    #[cfg(not(feature = "sync"))]
     pub fn new() -> Self {
         Self(Rc::new(RefCell::new(xml::Documents::new())))
+    }
+
+    #[cfg(feature = "sync")]
+    pub fn new() -> Self {
+        Self(Arc::new(RwLock::new(xml::Documents::new())))
+    }
+}
+#[cfg(not(feature = "sync"))]
+impl<'a> BorrowWith<'a> for DocumentsRef {
+    type Read = Ref<'a, xml::Documents>;
+    type Write = RefMut<'a, xml::Documents>;
+
+    fn borrow(&'a self) -> Self::Read {
+        self.0.borrow()
+    }
+
+    fn borrow_mut(&'a self) -> Self::Write {
+        self.0.borrow_mut()
+    }
+}
+
+#[cfg(feature = "sync")]
+impl<'a> BorrowWith<'a> for DocumentsRef {
+    type Read = RwLockReadGuard<'a, xml::Documents>;
+    type Write = RwLockWriteGuard<'a, xml::Documents>;
+
+    fn borrow(&'a self) -> Self::Read {
+        self.0.read().unwrap()
+    }
+    
+    fn borrow_mut(&'a self) -> Self::Write {
+        self.0.write().unwrap()
     }
 }
 

--- a/xee-interpreter/src/context/mod.rs
+++ b/xee-interpreter/src/context/mod.rs
@@ -4,8 +4,10 @@ mod dynamic_context;
 mod dynamic_context_builder;
 mod static_context;
 mod static_context_builder;
+mod borrow;
 
 pub use dynamic_context::{DynamicContext, Variables};
 pub use dynamic_context_builder::{DocumentsRef, DynamicContextBuilder};
 pub use static_context::StaticContext;
 pub use static_context_builder::StaticContextBuilder;
+pub use borrow::BorrowWith;

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -21,6 +21,7 @@ use crate::span::SourceSpan;
 use crate::stack;
 use crate::xml;
 use crate::{error, pattern};
+use crate::context::BorrowWith;
 
 use super::instruction::{read_i16, read_instruction, read_u16, read_u8, EncodedInstruction};
 use super::runnable::Runnable;

--- a/xee-interpreter/src/library/accessor.rs
+++ b/xee-interpreter/src/library/accessor.rs
@@ -4,6 +4,7 @@ use xee_xpath_macros::xpath_fn;
 
 use crate::atomic;
 use crate::context;
+use crate::context::BorrowWith;
 use crate::error;
 use crate::function::StaticFunctionDescription;
 use crate::interpreter::Interpreter;

--- a/xee-interpreter/src/library/external.rs
+++ b/xee-interpreter/src/library/external.rs
@@ -2,7 +2,7 @@ use iri_string::types::{IriReferenceStr, IriString};
 use xee_xpath_macros::xpath_fn;
 
 use crate::{
-    context::DynamicContext, error, function::StaticFunctionDescription, sequence::Sequence,
+    context::{DynamicContext, BorrowWith}, error, function::StaticFunctionDescription, sequence::Sequence,
     wrap_xpath_fn,
 };
 

--- a/xee-interpreter/src/library/id.rs
+++ b/xee-interpreter/src/library/id.rs
@@ -2,7 +2,7 @@ use ahash::{HashSet, HashSetExt};
 use xee_xpath_macros::xpath_fn;
 use xot::{Node, Xot};
 
-use crate::context::DynamicContext;
+use crate::context::{DynamicContext, BorrowWith};
 use crate::error::Error;
 use crate::function::StaticFunctionDescription;
 use crate::interpreter::Interpreter;

--- a/xee-interpreter/src/library/parse.rs
+++ b/xee-interpreter/src/library/parse.rs
@@ -2,7 +2,7 @@
 
 use xee_xpath_macros::xpath_fn;
 
-use crate::{context, error, function, interpreter::Interpreter, sequence, wrap_xpath_fn};
+use crate::{context, context::BorrowWith, error, function, interpreter::Interpreter, sequence, wrap_xpath_fn};
 
 use super::StaticFunctionDescription;
 

--- a/xee-interpreter/src/xml/document_order.rs
+++ b/xee-interpreter/src/xml/document_order.rs
@@ -17,9 +17,13 @@
 // preorder count of this node.
 
 use std::cell::RefCell;
+#[cfg(feature = "sync")]
+use std::sync::{Arc, RwLock};
 
 use ahash::{HashMap, HashMapExt};
 use xot::Xot;
+
+use crate::context::BorrowWith;
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub(crate) struct DocumentOrder(usize, usize);
@@ -47,6 +51,7 @@ impl<'a> DocumentOrderAccess<'a> {
     }
 }
 
+#[cfg(not(feature = "sync"))]
 #[derive(Debug, Clone)]
 pub(crate) struct DocumentOrderAnnotations {
     // each document has a different id, so track this
@@ -54,11 +59,30 @@ pub(crate) struct DocumentOrderAnnotations {
     map: RefCell<HashMap<xot::Node, DocumentOrder>>,
 }
 
+#[cfg(feature = "sync")]
+#[derive(Debug, Clone)]
+pub(crate) struct DocumentOrderAnnotations {
+    // each document has a different id, so track this
+    document_id: Arc<RwLock<usize>>,
+    map: Arc<RwLock<HashMap<xot::Node, DocumentOrder>>>,
+}
+
 impl DocumentOrderAnnotations {
+    #[cfg(not(feature = "sync"))]
     pub(crate) fn new() -> Self {
+        use num::zero;
+
         Self {
             map: RefCell::new(HashMap::new()),
             document_id: RefCell::new(0),
+        }
+    }
+
+    #[cfg(feature = "sync")]
+    pub(crate) fn new() -> Self {
+        Self {
+            map: Arc::new(RwLock::new(HashMap::new())),
+            document_id: Arc::new(RwLock::new(0)),
         }
     }
 

--- a/xee-testrunner/src/environment/source.rs
+++ b/xee-testrunner/src/environment/source.rs
@@ -6,6 +6,7 @@ use std::path::{Path, PathBuf};
 
 use xee_xpath::{context, Documents, Queries, Query};
 use xee_xpath_load::{convert_string, ContextLoadable};
+use xee_interpreter::context::BorrowWith;
 
 use crate::catalog::LoadContext;
 use crate::metadata::Metadata;

--- a/xee-xpath/Cargo.toml
+++ b/xee-xpath/Cargo.toml
@@ -14,6 +14,7 @@ homepage = "https://github.com/Paligo/xee"
 
 [features]
 serde = ["xee-xpath-ast/serde", "xee-interpreter/serde"]
+sync = ["xee-interpreter/sync"]
 
 [dependencies]
 xee-xpath-compiler = { path = "../xee-xpath-compiler", version = "0.1.5" }

--- a/xee-xpath/src/documents.rs
+++ b/xee-xpath/src/documents.rs
@@ -1,6 +1,6 @@
 use iri_string::types::IriStr;
 use xee_interpreter::{
-    context::DocumentsRef,
+    context::{DocumentsRef, BorrowWith},
     xml::{DocumentHandle, DocumentsError},
 };
 use xot::Xot;

--- a/xee-xpath/src/itemable.rs
+++ b/xee-xpath/src/itemable.rs
@@ -1,4 +1,4 @@
-use xee_interpreter::sequence::Item;
+use xee_interpreter::{context::BorrowWith, sequence::Item};
 
 use crate::{error::Result, DocumentHandle, Documents};
 


### PR DESCRIPTION
This draft PR adds a new Cargo feature that, when enabled, uses `Arc` and `RwLock` instead of `Rc` and `RefCell` to allow sharing `DocumentsRef` across threads. In particular, this allows `DocumentsRef` to be stored as a field in a struct marked with PyO3 as `#[pyclass]`, as that attribute requires `DocumentsRef: Send + Sync`.

By making synchronization conditioned on a feature, existing single-thread performance can be preserved, while allowing consuming libraries that need synchronization primitives to explicitly opt-in to that functionality.

To enable the new feature, this PR also adds a new trait, `BorrowWith`, that differs from the `std::borrow::Borrow` trait by allowing implementers to use custom types as borrow targets as long as those custom types satisfy the appropriate lifetimes. This trait is incomplete, missing bounds to ensure that the target types are appropriate for use as borrowed references and comments indicating the purpose of the trait; it is included regardless so as to solicit initial discussions.

See also: https://github.com/Paligo/xee/issues/66