### PR TITLE
Make Map and Array iteration methods public

### DIFF
--- a/xee-interpreter/src/function/array.rs
+++ b/xee-interpreter/src/function/array.rs
@@ -33,7 +33,7 @@ impl Array {
         self.0.get(index)
     }
 
-    pub(crate) fn iter(&self) -> impl DoubleEndedIterator<Item = &sequence::Sequence> {
+    pub fn iter(&self) -> impl DoubleEndedIterator<Item = &sequence::Sequence> {
         self.0.iter()
     }
 
@@ -98,7 +98,7 @@ impl Array {
         Some(Self::new(vec))
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         self.0.len()
     }
 

--- a/xee-interpreter/src/function/map.rs
+++ b/xee-interpreter/src/function/map.rs
@@ -71,7 +71,7 @@ impl Map {
         Ok(Map::from_map(result))
     }
 
-    pub(crate) fn len(&self) -> usize {
+    pub fn len(&self) -> usize {
         match self {
             Map::Empty(map) => map.len(),
             Map::One(map) => map.len(),
@@ -85,21 +85,21 @@ impl Map {
             Map::Many(map) => map.is_empty(),
         }
     }
-    pub(crate) fn get(&self, key: &atomic::Atomic) -> Option<&sequence::Sequence> {
+    pub fn get(&self, key: &atomic::Atomic) -> Option<&sequence::Sequence> {
         match self {
             Map::Empty(map) => map.get(key),
             Map::One(map) => map.get(key),
             Map::Many(map) => map.get(key),
         }
     }
-    pub(crate) fn keys(&self) -> Box<dyn Iterator<Item = &atomic::Atomic> + '_> {
+    pub fn keys(&self) -> Box<dyn Iterator<Item = &atomic::Atomic> + '_> {
         match self {
             Map::Empty(map) => Box::new(map.keys()),
             Map::One(map) => Box::new(map.keys()),
             Map::Many(map) => Box::new(map.keys()),
         }
     }
-    pub(crate) fn entries(
+    pub fn entries(
         &self,
     ) -> Box<dyn Iterator<Item = (&atomic::Atomic, &sequence::Sequence)> + '_> {
         match self {


### PR DESCRIPTION
## Summary

- Change visibility of `Map::keys()`, `Map::get()`, `Map::entries()`, `Map::len()` from `pub(crate)` to `pub`
- Change visibility of `Array::iter()`, `Array::len()` from `pub(crate)` to `pub`

## Motivation

The `Map` type's introspection methods (`keys()`, `entries()`, `get()`, `len()`) and `Array`'s `iter()` / `len()` are currently `pub(crate)`, making it impossible for downstream crates to inspect map/array contents without going through `Sequence::serialize()`.

### Use case

I'm building [tractor](https://github.com/boukeversteegh/tractor), a code query tool that uses xee-xpath. When a user writes a map constructor whose value is a multi-item sequence:

```xpath
map { "methods": //method/name/string(.) }
```

The JSON serializer correctly returns `Err(SERE0023)` since JSON can't represent bare sequences. But because there's no public API to iterate the map's entries, I can't build my own representation of the data — I have to work around it with an XPath normalization expression (`map:for-each` + self-application trick) to wrap sequences in arrays before re-serializing.

Making these methods `pub` instead of `pub(crate)` lets downstream code directly convert `Map`/`Array` into their own IR.

This would also help with issue #77 (Hash for Sequence/Item) since external consumers could participate in the hashing.

## Test plan

- [x] `cargo check` passes — no compilation errors
- [ ] Existing tests should pass unchanged (visibility-only change, no logic changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)