### PR TITLE
Fix predicate numeric probe erroring on multi-item sequences

### DIFF
--- a/vendor/xpath-tests/filters
+++ b/vendor/xpath-tests/filters
@@ -1991,11 +1991,6 @@ K2-NodeTest-19
 = prod-PathExpr
 = prod-PositionalVar
 = prod-Predicate
-K-FilterExpr-38
-K-FilterExpr-40
-K-FilterExpr-92
-K-FilterExpr-93
-K-FilterExpr-94
 = prod-QuantifiedExpr
 = prod-ReturnClause
 = prod-SchemaImport

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -1132,13 +1132,11 @@ impl<'a> Interpreter<'a> {
                                 "Appending a whole document is not supported yet",
                             )));
                         }
-                        xot::Value::Text(text) => {
-                            // zero length text nodes are skipped
-                            // Can this even exist, or does Xot not have
-                            // them anyway?
-                            if text.get().is_empty() {
-                                continue;
-                            }
+                        // zero length text nodes are skipped
+                        // Can this even exist, or does Xot not have
+                        // them anyway?
+                        xot::Value::Text(text) if text.get().is_empty() => {
+                            continue;
                         }
                         _ => {}
                     }

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -1045,11 +1045,13 @@ impl<'a> Interpreter<'a> {
 
     fn pop_is_numeric(&mut self) -> error::Result<bool> {
         let value = self.state.pop()?;
-        let a = value.atomized_option(self.state.xot())?;
-        if let Some(a) = a {
-            Ok(a.is_numeric())
-        } else {
-            Ok(false)
+        // Only a single atomized value can be numeric; an empty or multi-item
+        // sequence is not numeric (and must not error — the caller falls back
+        // to EBV for those).
+        let mut atomized = value.atomized(self.state.xot());
+        match (atomized.next(), atomized.next()) {
+            (Some(only), None) => Ok(only?.is_numeric()),
+            _ => Ok(false),
         }
     }
 

--- a/xee-interpreter/src/library/map.rs
+++ b/xee-interpreter/src/library/map.rs
@@ -162,7 +162,7 @@ fn find_helper(
                 function::Function::Array(array) => {
                     for entry in array.iter() {
                         let found = find_helper(entry, key.clone())?;
-                        result.extend(found.into_iter())
+                        result.extend(found)
                     }
                 }
                 function::Function::Map(map) => {
@@ -171,7 +171,7 @@ fn find_helper(
                             result.push(v.clone());
                         }
                         let found = find_helper(v, key.clone())?;
-                        result.extend(found.into_iter())
+                        result.extend(found)
                     }
                 }
                 _ => {}

--- a/xee-xpath/tests/snapshots/xpath__sequence_predicate_sequence_too_long.snap
+++ b/xee-xpath/tests/snapshots/xpath__sequence_predicate_sequence_too_long.snap
@@ -4,7 +4,7 @@ expression: "run(\"(1, 2, 3)[(2, 3)]\")"
 ---
 Err(
     SpannedError {
-        error: XPTY0004,
+        error: FORG0006,
         span: Some(
             SourceSpan(
                 10,

--- a/xee-xpath/tests/xpath.rs
+++ b/xee-xpath/tests/xpath.rs
@@ -396,6 +396,23 @@ fn test_sequence_predicate_sequence_empty() {
 }
 
 #[test]
+fn test_node_predicate_with_multiple_children() -> error::Result<()> {
+    // Regression: `a[b]` must match even when an `<a>` has multiple `<b>`
+    // children. The inner sequence should be treated as a node sequence and
+    // evaluated via EBV, not rejected by the numeric-predicate probe.
+    assert_nodes(
+        r#"<root><a><b>1</b></a><a><b>2</b><b>3</b></a></root>"#,
+        "//a[b]",
+        |xot, root| {
+            let root_el = xot.document_element(root).unwrap();
+            let a1 = xot.first_child(root_el).unwrap();
+            let a2 = xot.next_sibling(a1).unwrap();
+            vec![a1, a2]
+        },
+    )
+}
+
+#[test]
 fn test_child_axis_step1() -> error::Result<()> {
     assert_nodes(r#"<doc><a/><b/></doc>"#, "doc/*", |xot, root| {
         let doc_el = xot.document_element(root).unwrap();

--- a/xee-xslt-ast/src/whitespace.rs
+++ b/xee-xslt-ast/src/whitespace.rs
@@ -14,12 +14,11 @@ pub(crate) fn strip_whitespace(xot: &mut Xot, names: &Names, node: Node) {
     for edge in xot.traverse(node) {
         match edge {
             NodeEdge::Start(node) => match xot.value(node) {
-                Value::Text(text) => {
+                Value::Text(text)
                     if is_xml_whitespace(text.get())
-                        && !is_xml_space_preserve(xot, names, node, &xml_space_preserve)
-                    {
-                        to_remove.push(node);
-                    }
+                        && !is_xml_space_preserve(xot, names, node, &xml_space_preserve) =>
+                {
+                    to_remove.push(node);
                 }
                 Value::Element(_) => {
                     if let Some(xml_space) = xot.attributes(node).get(xot.xml_space_name()) {


### PR DESCRIPTION
Fixes #147.

## Summary
- `pop_is_numeric` used `Value::atomized_option`, which raises `XPTY0004` on any sequence of length > 1. That turned predicates like `a[b]` into errors whenever an `<a>` had more than one `<b>` child, instead of falling through to the effective-boolean-value path the XPath spec requires.
- The fix returns `false` for empty or multi-item atomized sequences so the EBV path handles them. Only a single atomized value can be a numeric predicate; anything else is not numeric by definition.

## Behavior change
- `a[b]` (and `//lambda[body/block/expression_statement]`, etc.) now match correctly when the inner path can yield more than one node.
- `(1, 2, 3)[(2, 3)]` still errors, but now with `FORG0006` — the correct spec error for applying EBV to a heterogeneous non-node multi-item sequence. One snapshot updated to reflect this.

## Tests
- New regression `test_node_predicate_with_multiple_children` covering `//a[b]` against `<root><a><b>…</b></a><a><b>…</b><b>…</b></a></root>`.
- `cargo test --workspace` — all green.
- `cargo clippy --all-targets --all-features -- -D warnings` — clean on Rust 1.95.0.

## QT3 conformance gain
Re-running `xee-testrunner update vendor/xpath-tests/` shrank `vendor/xpath-tests/filters` by 5 tests under `prod-Predicate`, all the same bug class:

```
K-FilterExpr-38   (1, 2, 3)[(xs:anyURI("..."), xs:anyURI("..."))] — expects FORG0006
K-FilterExpr-40   (similar)
K-FilterExpr-92   (1, 2, 3)[1, 2]                                  — expects FORG0006
K-FilterExpr-93   (1, 2, 3)[1, "a string"]                         — expects FORG0006
K-FilterExpr-94   (1, 2, 3)["a string", 1]                         — expects FORG0006
```

Before the fix these threw `XPTY0004` (wrong error). After the fix they throw `FORG0006` (EBV-on-heterogeneous-non-node-sequence), matching the spec. The filter update is included in this PR so conformance tracking stays tight.

## Bundled clippy cleanup (happy to split if preferred)
CI runs on the floating `stable` toolchain and Rust 1.95.0 promoted a few lints to errors. Fixed in a separate commit on this branch:
- `interpret.rs`: `collapsible_match` — merged nested `if` into a guarded match arm.
- `library/map.rs` (×2): `useless_conversion` — dropped `.into_iter()` inside `Vec::extend`.
- `xslt-ast/whitespace.rs`: `collapsible_match` — same pattern.

Purely mechanical; no behavior change. If you'd rather merge this as a standalone PR, say the word and I'll split the commit out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)