### PR TITLE
Serialize years above 9999 without chrono's leading '+'

### DIFF
--- a/xee-interpreter/src/atomic/cast_datetime.rs
+++ b/xee-interpreter/src/atomic/cast_datetime.rs
@@ -62,7 +62,8 @@ impl atomic::Atomic {
         let mut s = String::new();
         let offset = date_time.offset;
         let date_time = date_time.date_time;
-        s.push_str(&date_time.format("%Y-%m-%dT%H:%M:%S").to_string());
+        Self::push_canonical_year(&mut s, date_time.year());
+        s.push_str(&date_time.format("-%m-%dT%H:%M:%S").to_string());
         let millis = date_time.and_utc().timestamp_subsec_millis();
         Self::push_millis(&mut s, millis);
         if let Some(offset) = offset {
@@ -75,7 +76,8 @@ impl atomic::Atomic {
         date_time: &chrono::DateTime<chrono::FixedOffset>,
     ) -> String {
         let mut s = String::new();
-        s.push_str(&date_time.format("%Y-%m-%dT%H:%M:%S").to_string());
+        Self::push_canonical_year(&mut s, date_time.year());
+        s.push_str(&date_time.format("-%m-%dT%H:%M:%S").to_string());
         let millis = date_time.timestamp_subsec_millis();
         Self::push_millis(&mut s, millis);
         let offset = date_time.offset();
@@ -100,7 +102,8 @@ impl atomic::Atomic {
         let mut s = String::new();
         let offset = date.offset;
         let date = date.date;
-        s.push_str(&date.format("%Y-%m-%d").to_string());
+        Self::push_canonical_year(&mut s, date.year());
+        s.push_str(&date.format("-%m-%d").to_string());
         if let Some(offset) = offset {
             Self::push_canonical_time_zone_offset(&mut s, &offset);
         }
@@ -203,6 +206,16 @@ impl atomic::Atomic {
         }
         if s != Decimal::from(0) {
             v.push_str(&format!("{}S", s));
+        }
+    }
+
+    fn push_canonical_year(s: &mut String, year: i32) {
+        // chrono's %Y writes years above 9999 with a leading '+', which is
+        // not part of the XSD lexical space, so write the year ourselves
+        if year >= 0 {
+            s.push_str(&format!("{:04}", year));
+        } else {
+            s.push_str(&format!("-{:04}", year.abs()));
         }
     }
 

--- a/xee-xpath/tests/canonical_years.rs
+++ b/xee-xpath/tests/canonical_years.rs
@@ -1,0 +1,58 @@
+// Canonical serialization of years outside 1..=9999.
+//
+// chrono's %Y formats years above 9999 with a leading '+', which is not
+// valid in XSD lexical space, so the engine's own output failed to cast
+// back: xs:dateTime(string(xs:dateTime("10000-01-01T00:00:00Z"))) raised
+// FORG0001.
+
+use xee_xpath::{error, Documents, Queries, Query};
+
+fn eval(xpath: &str) -> error::Result<String> {
+    let mut documents = Documents::new();
+    let queries = Queries::default();
+    let q = queries.one(xpath, |_, item| Ok(item.try_into_value::<String>()?))?;
+    q.execute_build_context(&mut documents, |_| {})
+}
+
+#[test]
+fn test_five_digit_years_serialize_without_plus() {
+    assert_eq!(
+        eval(r#"string(xs:dateTime("10000-01-01T00:00:00Z"))"#).unwrap(),
+        "10000-01-01T00:00:00Z"
+    );
+    assert_eq!(
+        eval(r#"string(xs:dateTimeStamp("10000-01-01T00:00:00Z"))"#).unwrap(),
+        "10000-01-01T00:00:00Z"
+    );
+    assert_eq!(
+        eval(r#"string(xs:date("10000-01-01"))"#).unwrap(),
+        "10000-01-01"
+    );
+}
+
+#[test]
+fn test_five_digit_year_round_trips_through_the_engine() {
+    assert_eq!(
+        eval(r#"string(xs:dateTime(string(xs:dateTime("10000-01-01T00:00:00Z"))))"#).unwrap(),
+        "10000-01-01T00:00:00Z"
+    );
+    assert_eq!(
+        eval(r#"string(xs:date(string(xs:date("10000-01-01"))))"#).unwrap(),
+        "10000-01-01"
+    );
+}
+
+#[test]
+fn test_other_year_forms_stay_canonical() {
+    // negative years and year zero were already canonical
+    assert_eq!(
+        eval(r#"string(xs:dateTime("-0005-03-01T12:00:00"))"#).unwrap(),
+        "-0005-03-01T12:00:00"
+    );
+    assert_eq!(
+        eval(r#"string(xs:date("0000-01-01"))"#).unwrap(),
+        "0000-01-01"
+    );
+    // the gregorian types formatted years manually all along
+    assert_eq!(eval(r#"string(xs:gYear("10000"))"#).unwrap(), "10000");
+}


### PR DESCRIPTION
Fixes #153.

`string(xs:dateTime("10000-01-01T00:00:00Z"))` produced `"+10000-01-01T00:00:00Z"` - chrono's `%Y` switches to a signed, ISO-8601-expanded representation for years above 9999, which is not valid XSD lexical form. The engine's own cast rejected its own output: `xs:dateTime(string(xs:dateTime("10000-01-01T00:00:00Z")))` raised `FORG0001`.

The fix writes the year manually in `canonical_date_time`, `canonical_date_time_stamp`, and `canonical_date` via a small `push_canonical_year` helper, mirroring what `canonical_g_year`/`canonical_g_year_month` already did (those were unaffected). Negative years and year `0000` keep their existing (already-canonical) forms, pinned by tests.

## Testing

- New `xee-xpath/tests/canonical_years.rs`: the three affected types serialize five-digit years without `+`, the round trip through the engine's own cast now succeeds, and the already-correct forms (negative years, year 0000, `xs:gYear`) are pinned
- Full battery clean: `cargo fmt`, `clippy --all-targets --all-features -- -D warnings`, workspace `cargo test`, and both conformance suites with no regressions (XPath verified in release and debug mode, as CI runs it)

Generated with [Claude Code](https://claude.com/claude-code)
