### PR TITLE
feat: support top-level xsl:variable

### DIFF
--- a/xee-interpreter/src/function/inline_function.rs
+++ b/xee-interpreter/src/function/inline_function.rs
@@ -13,7 +13,7 @@ pub struct CastType {
     pub empty_sequence_allowed: bool,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct Name(pub(crate) String);
 
 impl Name {

--- a/xee-interpreter/src/interpreter/instruction.rs
+++ b/xee-interpreter/src/interpreter/instruction.rs
@@ -78,6 +78,8 @@ pub enum Instruction {
     CopyShallow,
     CopyDeep,
     ApplyTemplates(u16),
+    LoadGlobal(u16),
+    SetGlobal(u16),
     PrintTop,
     PrintStack,
 }
@@ -157,6 +159,8 @@ pub(crate) enum EncodedInstruction {
     ApplyTemplates,
     CopyShallow,
     CopyDeep,
+    LoadGlobal,
+    SetGlobal,
     PrintTop,
     PrintStack,
 }
@@ -197,6 +201,14 @@ pub(crate) fn decode_instruction(bytes: &[u8]) -> (Instruction, usize) {
         EncodedInstruction::ClosureVar => {
             let variable = u16::from_le_bytes([bytes[1], bytes[2]]);
             (Instruction::ClosureVar(variable), 3)
+        }
+        EncodedInstruction::LoadGlobal => {
+            let index = u16::from_le_bytes([bytes[1], bytes[2]]);
+            (Instruction::LoadGlobal(index), 3)
+        }
+        EncodedInstruction::SetGlobal => {
+            let index = u16::from_le_bytes([bytes[1], bytes[2]]);
+            (Instruction::SetGlobal(index), 3)
         }
         EncodedInstruction::Comma => (Instruction::Comma, 1),
         EncodedInstruction::CurlyArray => (Instruction::CurlyArray, 1),
@@ -339,6 +351,14 @@ pub fn encode_instruction(instruction: Instruction, bytes: &mut Vec<u8>) {
         Instruction::ClosureVar(variable) => {
             bytes.push(EncodedInstruction::ClosureVar.to_u8().unwrap());
             bytes.extend_from_slice(&variable.to_le_bytes());
+        }
+        Instruction::LoadGlobal(index) => {
+            bytes.push(EncodedInstruction::LoadGlobal.to_u8().unwrap());
+            bytes.extend_from_slice(&index.to_le_bytes());
+        }
+        Instruction::SetGlobal(index) => {
+            bytes.push(EncodedInstruction::SetGlobal.to_u8().unwrap());
+            bytes.extend_from_slice(&index.to_le_bytes());
         }
         Instruction::Comma => bytes.push(EncodedInstruction::Comma.to_u8().unwrap()),
         Instruction::CurlyArray => bytes.push(EncodedInstruction::CurlyArray.to_u8().unwrap()),
@@ -530,6 +550,7 @@ pub fn instruction_size(instruction: &Instruction) -> usize {
         | Instruction::ReturnConvert(_)
         | Instruction::JumpIfFalse(_) => 3,
         Instruction::ApplyTemplates(_) => 3,
+        Instruction::LoadGlobal(_) | Instruction::SetGlobal(_) => 3,
     }
 }
 

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -176,6 +176,16 @@ impl<'a> Interpreter<'a> {
                     let index = self.read_u16();
                     self.state.push_closure_var(index as usize)?;
                 }
+                EncodedInstruction::LoadGlobal => {
+                    let index = self.read_u16();
+                    let value = self.state.get_global(index as usize);
+                    self.state.push_value(value);
+                }
+                EncodedInstruction::SetGlobal => {
+                    let index = self.read_u16();
+                    let value = self.state.pop_value();
+                    self.state.set_global(index as usize, value);
+                }
                 EncodedInstruction::Comma => {
                     let b = self.state.pop()?;
                     let a = self.state.pop()?;

--- a/xee-interpreter/src/interpreter/state.rs
+++ b/xee-interpreter/src/interpreter/state.rs
@@ -40,6 +40,10 @@ pub struct State<'a> {
     stack: Vec<stack::Value>,
     build_stack: Vec<BuildStackEntry>,
     frames: ArrayVec<Frame, FRAMES_MAX>,
+    // Global variable values, indexed by their declaration order. They live for
+    // the whole run so every frame (main, rules, named templates) reads the same
+    // values through LoadGlobal.
+    globals: Vec<stack::Value>,
     regex_cache: RefCell<HashMap<RegexKey, Rc<regexml::Regex>>>,
     pub(crate) xot: &'a mut Xot,
 }
@@ -87,9 +91,24 @@ impl<'a> State<'a> {
             stack: vec![],
             build_stack: vec![],
             frames: ArrayVec::new(),
+            globals: vec![],
             regex_cache: RefCell::new(HashMap::new()),
             xot,
         }
+    }
+
+    pub(crate) fn set_global(&mut self, index: usize, value: stack::Value) {
+        if index >= self.globals.len() {
+            self.globals.resize(index + 1, stack::Value::Absent);
+        }
+        self.globals[index] = value;
+    }
+
+    pub(crate) fn get_global(&self, index: usize) -> stack::Value {
+        self.globals
+            .get(index)
+            .cloned()
+            .unwrap_or(stack::Value::Absent)
     }
 
     pub(crate) fn push<T>(&mut self, sequence: T)

--- a/xee-ir/src/compile.rs
+++ b/xee-ir/src/compile.rs
@@ -2,7 +2,7 @@ use ahash::HashMapExt;
 use xee_interpreter::{context::StaticContext, error::SpannedResult, interpreter::Program};
 
 use crate::{
-    declaration_compiler::{DeclarationCompiler, ModeIds},
+    declaration_compiler::{DeclarationCompiler, GlobalIds, ModeIds},
     ir, FunctionBuilder, FunctionCompiler, Scopes,
 };
 
@@ -11,7 +11,9 @@ pub fn compile_xpath(expr: ir::ExprS, static_context: StaticContext) -> SpannedR
     let mut scopes = Scopes::new();
     let builder = FunctionBuilder::new(&mut program);
     let empty_mode_ids = ModeIds::new();
-    let mut compiler = FunctionCompiler::new(builder, &mut scopes, &empty_mode_ids);
+    let empty_global_ids = GlobalIds::new();
+    let mut compiler =
+        FunctionCompiler::new(builder, &mut scopes, &empty_mode_ids, &empty_global_ids);
     compiler.compile_expr(&expr)?;
     Ok(program)
 }

--- a/xee-ir/src/declaration_compiler.rs
+++ b/xee-ir/src/declaration_compiler.rs
@@ -29,6 +29,7 @@ impl RuleBuilder {
 }
 
 pub type ModeIds = HashMap<ir::ApplyTemplatesModeValue, ModeId>;
+pub type GlobalIds = HashMap<ir::Name, usize>;
 
 pub struct DeclarationCompiler<'a> {
     program: &'a mut interpreter::Program,
@@ -36,6 +37,7 @@ pub struct DeclarationCompiler<'a> {
     rule_declaration_order: i64,
     rule_builders: HashMap<ir::ModeValue, Vec<RuleBuilder>>,
     mode_ids: ModeIds,
+    global_ids: GlobalIds,
 }
 
 impl<'a> DeclarationCompiler<'a> {
@@ -46,12 +48,18 @@ impl<'a> DeclarationCompiler<'a> {
             rule_declaration_order: 0,
             rule_builders: HashMap::new(),
             mode_ids: HashMap::new(),
+            global_ids: HashMap::new(),
         }
     }
 
     fn function_compiler(&mut self) -> FunctionCompiler<'_> {
         let function_builder = FunctionBuilder::new(self.program);
-        FunctionCompiler::new(function_builder, &mut self.scopes, &self.mode_ids)
+        FunctionCompiler::new(
+            function_builder,
+            &mut self.scopes,
+            &self.mode_ids,
+            &self.global_ids,
+        )
     }
 
     pub fn compile_declarations(
@@ -61,6 +69,12 @@ impl<'a> DeclarationCompiler<'a> {
         // first keep track of what modes exist, to create a ModeId for them. We do
         // this early so any mode reference within apply-templates will resolve.
         self.compile_modes(declarations);
+
+        // register a slot id per global variable so a reference anywhere, in main
+        // or in a rule, compiles to LoadGlobal.
+        for (id, name) in declarations.global_variables.iter().enumerate() {
+            self.global_ids.insert(name.clone(), id);
+        }
 
         for rule in &declarations.rules {
             self.compile_rule(rule)?;

--- a/xee-ir/src/function_compiler.rs
+++ b/xee-ir/src/function_compiler.rs
@@ -6,7 +6,7 @@ use xee_interpreter::interpreter::instruction::Instruction;
 use xee_interpreter::span::SourceSpan;
 use xee_interpreter::{error, function, sequence};
 
-use crate::declaration_compiler::ModeIds;
+use crate::declaration_compiler::{GlobalIds, ModeIds};
 use crate::ir;
 
 use super::builder::{BackwardJumpRef, ForwardJumpRef, FunctionBuilder, JumpCondition};
@@ -17,6 +17,7 @@ pub(crate) type Scopes = scope::Scopes<ir::Name>;
 pub struct FunctionCompiler<'a> {
     pub(crate) scopes: &'a mut Scopes,
     pub(crate) mode_ids: &'a ModeIds,
+    pub(crate) global_ids: &'a GlobalIds,
     pub(crate) builder: FunctionBuilder<'a>,
 }
 
@@ -25,11 +26,13 @@ impl<'a> FunctionCompiler<'a> {
         builder: FunctionBuilder<'a>,
         scopes: &'a mut Scopes,
         mode_ids: &'a ModeIds,
+        global_ids: &'a GlobalIds,
     ) -> Self {
         Self {
             builder,
             scopes,
             mode_ids,
+            global_ids,
         }
     }
 
@@ -38,6 +41,7 @@ impl<'a> FunctionCompiler<'a> {
         match &expr.value {
             ir::Expr::Atom(atom) => self.compile_atom(atom),
             ir::Expr::Let(let_) => self.compile_let(let_, span),
+            ir::Expr::SetGlobal(set_global) => self.compile_set_global(set_global, span),
             ir::Expr::Binary(binary) => self.compile_binary(binary, span),
             ir::Expr::Unary(unary) => self.compile_unary(unary, span),
             ir::Expr::FunctionDefinition(function_definition) => {
@@ -146,6 +150,15 @@ impl<'a> FunctionCompiler<'a> {
                 self.builder
                     .emit(Instruction::ClosureVar(index as u16), span);
                 Ok(())
+            } else if let Some(id) = self.global_ids.get(name) {
+                // Not a local or a closed-over name, so it must be a top-level
+                // xsl:variable; locals shadow globals as they are checked first.
+                let id = *id;
+                if id > u16::MAX as usize {
+                    return Err(Error::XPDY0130.with_span(span));
+                }
+                self.builder.emit(Instruction::LoadGlobal(id as u16), span);
+                Ok(())
             } else {
                 // TODO: this should be unreachable but
                 // the XSLT test suite for some reason triggers
@@ -179,6 +192,21 @@ impl<'a> FunctionCompiler<'a> {
         self.compile_expr(&let_.return_expr)?;
         self.builder.emit(Instruction::LetDone, span);
         self.scopes.pop_name();
+        Ok(())
+    }
+
+    fn compile_set_global(
+        &mut self,
+        set_global: &ir::SetGlobal,
+        span: SourceSpan,
+    ) -> error::SpannedResult<()> {
+        if set_global.id > u16::MAX as usize {
+            return Err(Error::XPDY0130.with_span(span));
+        }
+        self.compile_expr(&set_global.value)?;
+        self.builder
+            .emit(Instruction::SetGlobal(set_global.id as u16), span);
+        self.compile_expr(&set_global.return_expr)?;
         Ok(())
     }
 
@@ -342,6 +370,7 @@ impl<'a> FunctionCompiler<'a> {
             builder: nested_builder,
             scopes: self.scopes,
             mode_ids: self.mode_ids,
+            global_ids: self.global_ids,
         };
 
         for param in &function_definition.params {

--- a/xee-ir/src/ir.rs
+++ b/xee-ir/src/ir.rs
@@ -24,6 +24,7 @@ pub type ExprS = Spanned<Expr>;
 pub enum Expr {
     Atom(AtomS),
     Let(Let),
+    SetGlobal(SetGlobal),
     If(If),
     Binary(Binary),
     Unary(Unary),
@@ -89,6 +90,16 @@ pub struct ContextNames {
 pub struct Let {
     pub name: Name,
     pub var_expr: Box<ExprS>,
+    pub return_expr: Box<ExprS>,
+}
+
+// A top-level xsl:variable: evaluate `value` once and store it in the global
+// slot `id`, then continue with `return_expr`. The main function evaluates these
+// before applying templates, so every rule and named template can read them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SetGlobal {
+    pub id: usize,
+    pub value: Box<ExprS>,
     pub return_expr: Box<ExprS>,
 }
 
@@ -375,6 +386,9 @@ pub struct Declarations {
     pub rules: Vec<Rule>,
     pub modes: HashMap<Option<xmlname::OwnedName>, Mode>,
     pub functions: Vec<FunctionBinding>,
+    // Global variable names in declaration order; the index is the global slot id
+    // used by SetGlobal and LoadGlobal.
+    pub global_variables: Vec<Name>,
     pub main: FunctionDefinition,
     pub serialization_params: SerializationParameters,
 }
@@ -385,6 +399,7 @@ impl Declarations {
             rules: Vec::new(),
             modes: HashMap::new(),
             functions: Vec::new(),
+            global_variables: Vec::new(),
             main,
             serialization_params: SerializationParameters::new(),
         }

--- a/xee-ir/src/lib.rs
+++ b/xee-ir/src/lib.rs
@@ -10,7 +10,7 @@ mod variables;
 pub use binding::{Binding, Bindings};
 pub use builder::FunctionBuilder;
 pub use compile::{compile_xpath, compile_xslt};
-pub use declaration_compiler::ModeIds;
+pub use declaration_compiler::{GlobalIds, ModeIds};
 pub use function_compiler::FunctionCompiler;
 
 pub use scope::Scopes;

--- a/xee-ir/tests/test_xml_ir.rs
+++ b/xee-ir/tests/test_xml_ir.rs
@@ -2,7 +2,7 @@ use ahash::HashMapExt;
 use insta::assert_debug_snapshot;
 
 use xee_interpreter::interpreter::{instruction::decode_instructions, Program};
-use xee_ir::{ir, FunctionBuilder, FunctionCompiler, ModeIds, Scopes};
+use xee_ir::{ir, FunctionBuilder, FunctionCompiler, GlobalIds, ModeIds, Scopes};
 use xee_xpath_ast::span::Spanned;
 
 fn spanned<T>(t: T) -> Spanned<T> {
@@ -85,7 +85,13 @@ fn test_generate_element() {
     let function_builder = FunctionBuilder::new(&mut program);
     let mut scopes = Scopes::new();
     let empty_mode_ids = ModeIds::new();
-    let mut compiler = FunctionCompiler::new(function_builder, &mut scopes, &empty_mode_ids);
+    let empty_global_ids = GlobalIds::new();
+    let mut compiler = FunctionCompiler::new(
+        function_builder,
+        &mut scopes,
+        &empty_mode_ids,
+        &empty_global_ids,
+    );
 
     compiler.compile_expr(&outer_expr).unwrap();
 

--- a/xee-xslt-ast/src/ast_core.rs
+++ b/xee-xslt-ast/src/ast_core.rs
@@ -1705,6 +1705,12 @@ impl From<Variable> for OverrideContent {
     }
 }
 
+impl From<Variable> for Declaration {
+    fn from(v: Variable) -> Self {
+        Declaration::Variable(Box::new(v))
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct When {

--- a/xee-xslt-ast/src/names.rs
+++ b/xee-xslt-ast/src/names.rs
@@ -142,6 +142,7 @@ impl DeclarationName {
             DeclarationName::Accumulator => ast::Accumulator::parse_declaration(attributes),
             DeclarationName::Template => ast::Template::parse_declaration(attributes),
             DeclarationName::Output => ast::Output::parse_declaration(attributes),
+            DeclarationName::Variable => ast::Variable::parse_declaration(attributes),
             _ => Err(ElementError::Unsupported(format!(
                 "Unsupported declaration: {:?}",
                 &self

--- a/xee-xslt-compiler/src/ast_ir.rs
+++ b/xee-xslt-compiler/src/ast_ir.rs
@@ -12,6 +12,9 @@ use crate::{default_declarations::text_only_copy_declarations, priority::default
 struct IrConverter<'a> {
     variables: Variables,
     static_context: &'a StaticContext,
+    // Top-level xsl:variable declarations in order: the registered name and the
+    // declaration, kept so the main function can evaluate each into its global slot.
+    global_variables: Vec<(ir::Name, ast::Variable)>,
 }
 
 pub fn compile(
@@ -56,6 +59,7 @@ impl<'a> IrConverter<'a> {
         IrConverter {
             variables: Variables::new(),
             static_context,
+            global_variables: Vec::new(),
         }
     }
 
@@ -116,14 +120,79 @@ impl<'a> IrConverter<'a> {
     }
 
     fn transform(&mut self, transform: &ast::Transform) -> error::SpannedResult<ir::Declarations> {
+        // Register the global variable names first so every reference, in main or
+        // in a template, resolves while its declaration order fixes its slot id.
+        self.collect_globals(transform);
         let main_sequence_constructor = self.main_sequence_constructor();
-        let main = self.sequence_constructor_function(&main_sequence_constructor)?;
+        let main = self.main_function(&main_sequence_constructor)?;
         let mut declarations = ir::Declarations::new(main);
+        declarations.global_variables = self
+            .global_variables
+            .iter()
+            .map(|(name, _)| name.clone())
+            .collect();
 
         for declaration in &transform.declarations {
             self.declaration(&mut declarations, declaration)?;
         }
         Ok(declarations)
+    }
+
+    fn collect_globals(&mut self, transform: &ast::Transform) {
+        for declaration in &transform.declarations {
+            if let ast::Declaration::Variable(variable) = declaration {
+                let name = self.variables.new_var_name(&variable.name);
+                self.global_variables.push((name, (**variable).clone()));
+            }
+        }
+    }
+
+    // The main function evaluates each global variable into its slot before it
+    // applies templates, so the source document is the context and the values are
+    // ready for every rule.
+    fn main_function(
+        &mut self,
+        sequence_constructor: &ast::SequenceConstructor,
+    ) -> error::SpannedResult<ir::FunctionDefinition> {
+        let context_names = self.variables.push_context();
+        let bindings = self.sequence_constructor(sequence_constructor)?;
+        let mut body = bindings.expr();
+        let globals = self.global_variables.clone();
+        for (id, (_name, variable)) in globals.iter().enumerate().rev() {
+            let value = if let Some(select) = &variable.select {
+                self.expression(select)?
+            } else {
+                self.sequence_constructor(&variable.sequence_constructor)?
+            };
+            body = Spanned::new(
+                ir::Expr::SetGlobal(ir::SetGlobal {
+                    id,
+                    value: Box::new(value.expr()),
+                    return_expr: Box::new(body),
+                }),
+                (0..0).into(),
+            );
+        }
+        self.variables.pop_context();
+        let params = vec![
+            ir::Param {
+                name: context_names.item,
+                type_: None,
+            },
+            ir::Param {
+                name: context_names.position,
+                type_: None,
+            },
+            ir::Param {
+                name: context_names.last,
+                type_: None,
+            },
+        ];
+        Ok(ir::FunctionDefinition {
+            params,
+            return_type: None,
+            body: Box::new(body),
+        })
     }
 
     fn declaration(
@@ -136,6 +205,8 @@ impl<'a> IrConverter<'a> {
             Template(template) => self.template(declarations, template),
             Mode(mode) => self.mode(declarations, mode),
             Output(output) => self.output(declarations, output),
+            // Global variables are collected up front and woven into main.
+            Variable(_) => Ok(()),
             _ => Err(error::Error::Unsupported(format!(
                 "Declaration not supported: {:?}",
                 declaration

--- a/xee-xslt-compiler/tests/test_xslt.rs
+++ b/xee-xslt-compiler/tests/test_xslt.rs
@@ -1230,3 +1230,74 @@ fn test_basic_iterate_params() {
         "<o><baz>1</baz><baz>2</baz><baz>4</baz></o>"
     );
 }
+
+#[test]
+fn test_global_variable() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc/>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:variable name="greeting" select="'hello'"/>
+  <xsl:template match="/"><o><xsl:value-of select="$greeting"/></o></xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o>hello</o>");
+}
+
+#[test]
+fn test_global_variable_from_source() {
+    // A global is evaluated with the source document as the context, so it can
+    // read from the input tree.
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc/>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:variable name="root-name" select="name(/*)"/>
+  <xsl:template match="/"><o><xsl:value-of select="$root-name"/></o></xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o>doc</o>");
+}
+
+#[test]
+fn test_global_variable_references_earlier_global() {
+    // Globals evaluate in declaration order, so a later one can read an earlier.
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc/>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:variable name="a" select="'x'"/>
+  <xsl:variable name="b" select="concat($a, 'y')"/>
+  <xsl:template match="/"><o><xsl:value-of select="$b"/></o></xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o>xy</o>");
+}
+
+#[test]
+fn test_local_variable_shadows_global() {
+    let mut xot = Xot::new();
+    let output = evaluate(
+        &mut xot,
+        "<doc/>",
+        r#"
+<xsl:transform xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="3">
+  <xsl:variable name="v" select="'global'"/>
+  <xsl:template match="/">
+    <xsl:variable name="v" select="'local'"/>
+    <o><xsl:value-of select="$v"/></o>
+  </xsl:template>
+</xsl:transform>"#,
+    )
+    .unwrap();
+    assert_eq!(xml(&xot, output), "<o>local</o>");
+}


### PR DESCRIPTION
A stylesheet's global variables are the backbone of a real transform, holding document lookups and localisation that every template reads.

- Each top-level `xsl:variable` gets a slot, indexed by declaration order.
- The main function evaluates the globals into their slots before it applies templates, with the source document as the context, so a global can read from the input tree.
- Two instructions carry the values: `SetGlobal` stores a computed value, and `LoadGlobal` reads it. They live on the interpreter state for the whole run, so a rule or named template reads the same values even though it is invoked as its own function without a captured scope.
- A reference resolves to a local, then a closed-over name, then a global, so a local variable of the same name shadows the global.
- The AST parser gained the `xsl:variable` declaration, which it rejected before.

## Tests

`test_global_variable` reads a global inside a template, `test_global_variable_from_source` reads the source document, `test_global_variable_references_earlier_global` covers declaration order, and `test_local_variable_shadows_global` covers shadowing.

## Not covered

A global whose value references a later global reads an empty sequence, because the values fill in declaration order rather than by dependency.