### PR TITLE
Make Documents Send and Sync

### DIFF
--- a/xee-interpreter/src/context/dynamic_context.rs
+++ b/xee-interpreter/src/context/dynamic_context.rs
@@ -17,7 +17,7 @@ pub type Variables = AHashMap<xot::xmlname::OwnedName, sequence::Sequence>;
 
 // a dynamic context is created for each xpath evaluation
 #[derive(Debug)]
-pub struct DynamicContext<'a> {
+pub struct DynamicContext<'a, 'd> {
     // we keep a reference to the program
     program: &'a Program,
 
@@ -26,7 +26,7 @@ pub struct DynamicContext<'a> {
     // we want to mutate documents during evaluation, and this happens in
     // multiple spots. We use RefCell to manage that during runtime so we don't
     // need to make the whole thing immutable.
-    documents: DocumentsRef,
+    documents: DocumentsRef<'d>,
     variables: Variables,
     // TODO: we want to be able to control the creation of this outside,
     // as it needs to be the same for all evalutions of XSLT I believe
@@ -43,12 +43,12 @@ pub struct DynamicContext<'a> {
     environment_variables: HashMap<String, String>,
 }
 
-impl<'a> DynamicContext<'a> {
+impl<'a, 'd> DynamicContext<'a, 'd> {
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn new(
         program: &'a Program,
         context_item: Option<sequence::Item>,
-        documents: DocumentsRef,
+        documents: DocumentsRef<'d>,
         variables: Variables,
         current_datetime: chrono::DateTime<chrono::offset::FixedOffset>,
         default_collection: Option<sequence::Sequence>,
@@ -82,8 +82,8 @@ impl<'a> DynamicContext<'a> {
     }
 
     /// The documents in this context.
-    pub fn documents(&self) -> DocumentsRef {
-        self.documents.clone()
+    pub fn documents(&self) -> &DocumentsRef<'d> {
+        &self.documents
     }
 
     /// The variables in this context.

--- a/xee-interpreter/src/context/dynamic_context_builder.rs
+++ b/xee-interpreter/src/context/dynamic_context_builder.rs
@@ -1,4 +1,4 @@
-use std::{cell::RefCell, ops::Deref, rc::Rc};
+use std::{cell::RefCell, ops::Deref};
 
 use ahash::{HashMap, HashMapExt};
 use iri_string::types::{IriStr, IriString};
@@ -18,7 +18,6 @@ use super::{DynamicContext, Variables};
 pub struct DynamicContextBuilder<'a> {
     program: &'a interpreter::Program,
     context_item: Option<sequence::Item>,
-    documents: DocumentsRef,
     variables: Variables,
     current_datetime: chrono::DateTime<chrono::offset::FixedOffset>,
     default_collection: Option<sequence::Sequence>,
@@ -30,32 +29,14 @@ pub struct DynamicContextBuilder<'a> {
 
 /// A shallow wrapper around a collection of XML documents
 /// [`xml::Documents`]
-#[derive(Debug, Clone)]
-pub struct DocumentsRef(Rc<RefCell<xml::Documents>>);
+#[derive(Debug)]
+pub struct DocumentsRef<'a>(pub RefCell<&'a mut xml::Documents>);
 
-impl Deref for DocumentsRef {
-    type Target = RefCell<xml::Documents>;
+impl<'a> Deref for DocumentsRef<'a> {
+    type Target = RefCell<&'a mut xml::Documents>;
 
     fn deref(&self) -> &Self::Target {
         &self.0
-    }
-}
-
-impl From<xml::Documents> for DocumentsRef {
-    fn from(documents: xml::Documents) -> Self {
-        Self(Rc::new(RefCell::new(documents)))
-    }
-}
-
-impl DocumentsRef {
-    pub fn new() -> Self {
-        Self(Rc::new(RefCell::new(xml::Documents::new())))
-    }
-}
-
-impl Default for DocumentsRef {
-    fn default() -> Self {
-        Self::new()
     }
 }
 
@@ -65,7 +46,6 @@ impl<'a> DynamicContextBuilder<'a> {
         Self {
             program,
             context_item: None,
-            documents: DocumentsRef::new(),
             variables: Variables::new(),
             current_datetime: chrono::offset::Local::now().into(),
             default_collection: None,
@@ -87,14 +67,6 @@ impl<'a> DynamicContextBuilder<'a> {
     /// Set a node as the context item of the [`DynamicContext`].
     pub fn context_node(&mut self, node: xot::Node) -> &mut Self {
         self.context_item(sequence::Item::Node(node));
-        self
-    }
-
-    /// Set the documents of the [`DynamicContext`].
-    ///
-    /// You can give it either owned documents or a [`DocumentsRef`].
-    pub fn documents(&mut self, documents: impl Into<DocumentsRef>) -> &mut Self {
-        self.documents = documents.into();
         self
     }
 
@@ -170,11 +142,11 @@ impl<'a> DynamicContextBuilder<'a> {
     }
 
     /// Build the `DynamicContext`.
-    pub fn build(&self) -> DynamicContext<'_> {
+    pub fn build<'d>(&self, documents: DocumentsRef<'d>) -> DynamicContext<'a, 'd> {
         DynamicContext::new(
             self.program,
             self.context_item.clone(),
-            self.documents.clone(),
+            documents,
             self.variables.clone(),
             self.current_datetime,
             self.default_collection.clone(),

--- a/xee-interpreter/src/function/static_function.rs
+++ b/xee-interpreter/src/function/static_function.rs
@@ -52,8 +52,8 @@ impl FunctionKind {
     }
 }
 
-pub(crate) type StaticFunctionType = fn(
-    context: &DynamicContext,
+pub(crate) type StaticFunctionType = for<'a, 'd> fn(
+    context: &DynamicContext<'a, 'd>,
     interpreter: &mut interpreter::Interpreter,
     arguments: &[sequence::Sequence],
 ) -> error::Result<sequence::Sequence>;
@@ -193,7 +193,7 @@ impl StaticFunction {
 
     pub(crate) fn invoke(
         &self,
-        context: &DynamicContext,
+        context: &DynamicContext<'_, '_>,
         interpreter: &mut interpreter::Interpreter,
         arguments: Vec<sequence::Sequence>,
         closure_values: &[stack::Value],

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -283,7 +283,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                         &b,
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(result);
@@ -299,7 +299,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                         &b,
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(result);
@@ -311,7 +311,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                         b,
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(combined);
@@ -323,7 +323,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                         b,
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(combined);
@@ -335,7 +335,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                         b,
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(combined);
@@ -370,7 +370,7 @@ impl<'a, 'd> Interpreter<'a, 'd> {
                     let value = value.deduplicate(
                         self.runnable
                             .documents()
-                            .borrow()
+                            .borrow_mut()
                             .document_order_access(self.xot()),
                     )?;
                     self.state.push(value);

--- a/xee-interpreter/src/interpreter/interpret.rs
+++ b/xee-interpreter/src/interpreter/interpret.rs
@@ -26,8 +26,8 @@ use super::instruction::{read_i16, read_instruction, read_u16, read_u8, EncodedI
 use super::runnable::Runnable;
 use super::state::State;
 
-pub struct Interpreter<'a> {
-    runnable: &'a Runnable<'a>,
+pub struct Interpreter<'a, 'd> {
+    runnable: &'a Runnable<'a, 'd>,
     pub(crate) state: State<'a>,
 }
 
@@ -47,8 +47,8 @@ impl From<sequence::Item> for ContextInfo {
     }
 }
 
-impl<'a> Interpreter<'a> {
-    pub fn new(runnable: &'a Runnable<'a>, xot: &'a mut Xot) -> Self {
+impl<'a, 'd> Interpreter<'a, 'd> {
+    pub fn new(runnable: &'a Runnable<'a, 'd>, xot: &'a mut Xot) -> Self {
         Interpreter {
             runnable,
             state: State::new(xot),
@@ -59,7 +59,7 @@ impl<'a> Interpreter<'a> {
         self.state
     }
 
-    pub(crate) fn runnable(&self) -> &Runnable<'_> {
+    pub(crate) fn runnable(&self) -> &'a Runnable<'a, 'd> {
         self.runnable
     }
 

--- a/xee-interpreter/src/interpreter/program.rs
+++ b/xee-interpreter/src/interpreter/program.rs
@@ -62,7 +62,7 @@ impl Program {
     }
 
     /// Obtain a runnable version of this program, with a particular dynamic context.
-    pub fn runnable<'a>(&'a self, dynamic_context: &'a context::DynamicContext) -> Runnable<'a> {
+    pub fn runnable<'a, 'd>(&'a self, dynamic_context: &'a context::DynamicContext<'a, 'd>) -> Runnable<'a, 'd> {
         Runnable::new(self, dynamic_context)
     }
 

--- a/xee-interpreter/src/interpreter/runnable.rs
+++ b/xee-interpreter/src/interpreter/runnable.rs
@@ -19,17 +19,17 @@ use super::Interpreter;
 use super::Program;
 
 #[derive(Debug)]
-pub struct Runnable<'a> {
+pub struct Runnable<'a, 'd> {
     program: &'a Program,
     // TODO: this should be private, but is needed right now
     // to implement call_static without lifetime issues.
     // We could possibly obtain context from the interpreter directly,
     // but this leads to lifetime issues right now.
-    pub(crate) dynamic_context: &'a DynamicContext<'a>,
+    pub(crate) dynamic_context: &'a DynamicContext<'a, 'd>,
 }
 
-impl<'a> Runnable<'a> {
-    pub(crate) fn new(program: &'a Program, dynamic_context: &'a DynamicContext) -> Self {
+impl<'a, 'd> Runnable<'a, 'd> {
+    pub(crate) fn new(program: &'a Program, dynamic_context: &'a DynamicContext<'a, 'd>) -> Self {
         Self {
             program,
             dynamic_context,
@@ -106,11 +106,11 @@ impl<'a> Runnable<'a> {
         self.program
     }
 
-    pub fn dynamic_context(&self) -> &'a DynamicContext<'_> {
+    pub fn dynamic_context(&self) -> &'a DynamicContext<'a, 'd> {
         self.dynamic_context
     }
 
-    pub fn documents(&self) -> DocumentsRef {
+    pub fn documents(&self) -> &DocumentsRef<'d> {
         self.dynamic_context.documents()
     }
 

--- a/xee-interpreter/src/library/id.rs
+++ b/xee-interpreter/src/library/id.rs
@@ -24,7 +24,7 @@ fn id(
         interpreter.xot(),
         context
             .documents()
-            .borrow()
+            .borrow_mut()
             .document_order_access(interpreter.xot()),
     )
 }
@@ -47,7 +47,7 @@ fn element_with_id(
         interpreter.xot(),
         context
             .documents()
-            .borrow()
+            .borrow_mut()
             .document_order_access(interpreter.xot()),
     )
 }
@@ -56,7 +56,7 @@ fn ids_helper(
     arg: impl Iterator<Item = Result<String, Error>>,
     node: Node,
     xot: &Xot,
-    annotations: xml::DocumentOrderAccess,
+    mut annotations: xml::DocumentOrderAccess,
 ) -> Result<Vec<Node>, Error> {
     let document_node = xot.root(node);
     let mut result: Vec<Node> = Vec::new();
@@ -89,8 +89,8 @@ fn generate_id(
 ) -> String {
     if let Some(arg) = arg {
         let documents = context.documents();
-        let documents = documents.borrow();
-        let annotations = documents.document_order_access(interpreter.xot());
+        let mut documents = documents.borrow_mut();
+        let mut annotations = documents.document_order_access(interpreter.xot());
         let annotation = annotations.get(arg);
         annotation.generate_id()
     } else {

--- a/xee-interpreter/src/pattern/pattern_lookup.rs
+++ b/xee-interpreter/src/pattern/pattern_lookup.rs
@@ -11,17 +11,17 @@ pub struct PatternLookup<V: Clone> {
     pub(crate) patterns: Vec<(Pattern<function::InlineFunctionId>, V)>,
 }
 
-pub(crate) struct InterpreterPredicateMatcher<'a> {
-    interpreter: &'a mut Interpreter<'a>,
+pub(crate) struct InterpreterPredicateMatcher<'a, 'd> {
+    interpreter: &'a mut Interpreter<'a, 'd>,
 }
 
-impl<'a> InterpreterPredicateMatcher<'a> {
-    pub(crate) fn new(interpreter: &'a mut Interpreter<'a>) -> Self {
+impl<'a, 'd> InterpreterPredicateMatcher<'a, 'd> {
+    pub(crate) fn new(interpreter: &'a mut Interpreter<'a, 'd>) -> Self {
         Self { interpreter }
     }
 }
 
-impl PredicateMatcher for Interpreter<'_> {
+impl PredicateMatcher for Interpreter<'_, '_> {
     fn match_predicate(
         &mut self,
         inline_function_id: function::InlineFunctionId,

--- a/xee-interpreter/src/sequence/creation.rs
+++ b/xee-interpreter/src/sequence/creation.rs
@@ -121,7 +121,7 @@ impl Sequence {
 
     pub(crate) fn process_set_result(
         s: HashSet<xot::Node>,
-        annotations: xml::DocumentOrderAccess,
+        mut annotations: xml::DocumentOrderAccess,
     ) -> Self {
         // sort nodes by document order
         let mut nodes = s.into_iter().collect::<Vec<_>>();

--- a/xee-interpreter/src/sequence/traits.rs
+++ b/xee-interpreter/src/sequence/traits.rs
@@ -199,7 +199,7 @@ where
     fn precedes<J>(
         &'a self,
         other: &'a impl SequenceOrder<'a, J>,
-        annotations: xml::DocumentOrderAccess,
+        mut annotations: xml::DocumentOrderAccess,
     ) -> error::Result<bool>
     where
         J: Iterator<Item = Item> + 'a,
@@ -214,7 +214,7 @@ where
     fn follows<J>(
         &'a self,
         other: &'a impl SequenceOrder<'a, J>,
-        annotations: xml::DocumentOrderAccess,
+        mut annotations: xml::DocumentOrderAccess,
     ) -> error::Result<bool>
     where
         J: Iterator<Item = Item> + 'a,

--- a/xee-interpreter/src/xml/document.rs
+++ b/xee-interpreter/src/xml/document.rs
@@ -212,7 +212,7 @@ impl Documents {
         &self.annotations
     }
 
-    pub(crate) fn document_order_access<'a>(&'a self, xot: &'a Xot) -> DocumentOrderAccess<'a> {
+    pub(crate) fn document_order_access<'a>(&'a mut self, xot: &'a Xot) -> DocumentOrderAccess<'a> {
         self.annotations.access(xot)
     }
 }

--- a/xee-interpreter/src/xml/document_order.rs
+++ b/xee-interpreter/src/xml/document_order.rs
@@ -16,8 +16,6 @@
 // annotated node. From this we can determine the document id as well as the
 // preorder count of this node.
 
-use std::cell::RefCell;
-
 use ahash::{HashMap, HashMapExt};
 use xot::Xot;
 
@@ -34,15 +32,15 @@ impl DocumentOrder {
 
 pub(crate) struct DocumentOrderAccess<'a> {
     pub(crate) xot: &'a Xot,
-    pub(crate) annotations: &'a DocumentOrderAnnotations,
+    pub(crate) annotations: &'a mut DocumentOrderAnnotations,
 }
 
 impl<'a> DocumentOrderAccess<'a> {
-    pub(crate) fn new(xot: &'a Xot, annotations: &'a DocumentOrderAnnotations) -> Self {
+    pub(crate) fn new(xot: &'a Xot, annotations: &'a mut DocumentOrderAnnotations) -> Self {
         Self { xot, annotations }
     }
 
-    pub(crate) fn get(&self, node: xot::Node) -> DocumentOrder {
+    pub(crate) fn get(&mut self, node: xot::Node) -> DocumentOrder {
         self.annotations.get(node, self.xot)
     }
 }
@@ -50,32 +48,32 @@ impl<'a> DocumentOrderAccess<'a> {
 #[derive(Debug, Clone)]
 pub(crate) struct DocumentOrderAnnotations {
     // each document has a different id, so track this
-    document_id: RefCell<usize>,
-    map: RefCell<HashMap<xot::Node, DocumentOrder>>,
+    document_id: usize,
+    map: HashMap<xot::Node, DocumentOrder>,
 }
 
 impl DocumentOrderAnnotations {
     pub(crate) fn new() -> Self {
         Self {
-            map: RefCell::new(HashMap::new()),
-            document_id: RefCell::new(0),
+            map: HashMap::new(),
+            document_id: 0,
         }
     }
 
-    pub(crate) fn access<'a>(&'a self, xot: &'a Xot) -> DocumentOrderAccess<'a> {
+    pub(crate) fn access<'a>(&'a mut self, xot: &'a Xot) -> DocumentOrderAccess<'a> {
         DocumentOrderAccess::new(xot, self)
     }
 
-    pub(crate) fn get(&self, node: xot::Node, xot: &xot::Xot) -> DocumentOrder {
-        let document_order = self.map.borrow().get(&node).cloned();
+    pub(crate) fn get(&mut self, node: xot::Node, xot: &xot::Xot) -> DocumentOrder {
+        let document_order = self.map.get(&node).cloned();
         if let Some(document_order) = document_order {
             document_order
         } else {
             let (document_order, found_node) =
-                find_node_with_document_order(&self.map.borrow(), node, xot);
+                find_node_with_document_order(&self.map, node, xot);
             if let Some(document_order) = document_order {
                 annotation_with_document_order(
-                    &mut self.map.borrow_mut(),
+                    &mut self.map,
                     document_order,
                     found_node,
                     node,
@@ -84,14 +82,13 @@ impl DocumentOrderAnnotations {
             } else {
                 // if we increment document id, we should end up at
                 // a new one for this new fragment/document
-                *self.document_id.borrow_mut() += 1;
+                self.document_id += 1;
 
-                let document_order = DocumentOrder(*self.document_id.borrow(), 0);
+                let document_order = DocumentOrder(self.document_id, 0);
 
-                let mut map = self.map.borrow_mut();
-                map.insert(found_node, document_order);
+                self.map.insert(found_node, document_order);
                 // now create annotations for everything up to node
-                annotation_with_document_order(&mut map, document_order, found_node, node, xot)
+                annotation_with_document_order(&mut self.map, document_order, found_node, node, xot)
             }
         }
     }

--- a/xee-ir/tests/test_xml_ir.rs
+++ b/xee-ir/tests/test_xml_ir.rs
@@ -91,8 +91,9 @@ fn test_generate_element() {
 
     assert_debug_snapshot!(decode_instructions(&program.functions[0].chunk));
 
+    let mut dummy_docs = xee_interpreter::xml::Documents::new();
     let dynamic_context_builder = program.dynamic_context_builder();
-    let context = dynamic_context_builder.build();
+    let context = dynamic_context_builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut dummy_docs)));
 
     let mut xot = xot::Xot::new();
     let runnable = program.runnable(&context);

--- a/xee-testrunner/src/environment/core.rs
+++ b/xee-testrunner/src/environment/core.rs
@@ -176,9 +176,8 @@ impl EnvironmentSpec {
                     continue;
                 }
             };
-            let dynamic_context_builder = query.dynamic_context_builder(&documents);
-            let dynamic_context = dynamic_context_builder.build();
-            let result = query.execute_with_context(&mut documents, &dynamic_context)?;
+            let dynamic_context_builder = query.dynamic_context_builder();
+            let result = query.execute_with_builder(&mut documents, &dynamic_context_builder)?;
             variables.insert(param.name.clone(), result);
         }
         Ok(variables)

--- a/xee-testrunner/src/environment/source.rs
+++ b/xee-testrunner/src/environment/source.rs
@@ -75,18 +75,9 @@ impl Source {
                 // down the line earlier and resolve earlier.
                 let full_path = base_dir.join(path);
                 // try to get the cached version of the document
-                {
-                    // scope borrowed_documents so we drop it afterward
-                    let borrowed_documents = documents.documents().borrow();
-
-                    // when we load something from a path, we first check if we
-                    // happen to know it under a URI already
-                    if let Some(uri) = &uri {
-                        // if we know it, we try to look it up
-                        let root = borrowed_documents.get_node_by_uri(uri);
-                        if let Some(root) = root {
-                            return Ok(root);
-                        }
+                if let Some(uri) = &uri {
+                    if let Some(root) = documents.documents().borrow().get_node_by_uri(uri) {
+                        return Ok(root);
                     }
                 }
 
@@ -96,34 +87,16 @@ impl Source {
                 let mut xml = String::new();
                 buf_reader.read_to_string(&mut xml)?;
 
-                let documents_ref = documents.documents().clone();
-                let handle = documents_ref.borrow_mut().add_string(
-                    documents.xot_mut(),
-                    uri.as_deref(),
-                    &xml,
-                )?;
-                Ok(documents
-                    .documents()
-                    .borrow()
-                    .get_node_by_handle(handle)
-                    .unwrap())
+                let handle = documents.add_string_with_optional_uri(uri.as_deref(), &xml)?;
+                Ok(documents.document_node(handle).unwrap())
             }
             SourceContent::Content(value) => {
                 // we don't try to get a cached version of the document, as
                 // that would be different each time. we just add it to documents
                 // and return it
                 // TODO: is this right?
-                let documents_ref = documents.documents().clone();
-                let handle = documents_ref.borrow_mut().add_string(
-                    documents.xot_mut(),
-                    uri.as_deref(),
-                    value,
-                )?;
-                Ok(documents
-                    .documents()
-                    .borrow()
-                    .get_node_by_handle(handle)
-                    .unwrap())
+                let handle = documents.add_string_with_optional_uri(uri.as_deref(), value)?;
+                Ok(documents.document_node(handle).unwrap())
             }
             SourceContent::ContentAndSelect(_value, _select) => {
                 todo!("Don't know yet how to execute xpath here")

--- a/xee-testrunner/src/testcase/assert.rs
+++ b/xee-testrunner/src/testcase/assert.rs
@@ -20,7 +20,7 @@ type XPathExpr = String;
 pub(crate) trait Assertable {
     fn assert_result(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {
@@ -32,7 +32,7 @@ pub(crate) trait Assertable {
 
     fn assert_value(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome;
@@ -67,7 +67,7 @@ impl AssertAnyOf {
 impl Assertable for AssertAnyOf {
     fn assert_result(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {
@@ -87,7 +87,7 @@ impl Assertable for AssertAnyOf {
 
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         _sequence: &Sequence,
     ) -> TestOutcome {
@@ -107,7 +107,7 @@ impl AssertAllOf {
 impl Assertable for AssertAllOf {
     fn assert_result(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {
@@ -123,7 +123,7 @@ impl Assertable for AssertAllOf {
 
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         _sequence: &Sequence,
     ) -> TestOutcome {
@@ -143,7 +143,7 @@ impl AssertNot {
 impl Assertable for AssertNot {
     fn assert_result(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {
@@ -159,7 +159,7 @@ impl Assertable for AssertNot {
 
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         _sequence: &Sequence,
     ) -> TestOutcome {
@@ -185,7 +185,7 @@ impl Assert {
 impl Assertable for Assert {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -219,7 +219,7 @@ impl AssertEq {
 impl Assertable for AssertEq {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -258,7 +258,7 @@ impl AssertDeepEq {
 impl Assertable for AssertDeepEq {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -297,7 +297,7 @@ impl AssertCount {
 impl Assertable for AssertCount {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -322,7 +322,7 @@ impl AssertPermutation {
 impl Assertable for AssertPermutation {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -388,7 +388,7 @@ impl AssertXml {
 impl Assertable for AssertXml {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -462,7 +462,7 @@ impl AssertEmpty {
 impl Assertable for AssertEmpty {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -492,7 +492,7 @@ impl AssertType {
 impl Assertable for AssertType {
     fn assert_value(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -528,7 +528,7 @@ impl AssertTrue {
 impl Assertable for AssertTrue {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -558,7 +558,7 @@ impl AssertFalse {
 impl Assertable for AssertFalse {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -588,7 +588,7 @@ impl AssertStringValue {
 impl Assertable for AssertStringValue {
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         sequence: &Sequence,
     ) -> TestOutcome {
@@ -656,7 +656,7 @@ impl AssertError {
 impl Assertable for AssertError {
     fn assert_result(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {
@@ -668,7 +668,7 @@ impl Assertable for AssertError {
 
     fn assert_value(
         &self,
-        _context: &DynamicContext<'_>,
+        _context: &DynamicContext<'_, '_>,
         _documents: &mut Documents,
         _sequence: &Sequence,
     ) -> TestOutcome {
@@ -755,7 +755,7 @@ pub(crate) enum TestCaseResult {
 impl TestCaseResult {
     pub(crate) fn assert_result(
         &self,
-        context: &DynamicContext<'_>,
+        context: &DynamicContext<'_, '_>,
         documents: &mut Documents,
         result: &error::ValueResult<Sequence>,
     ) -> TestOutcome {

--- a/xee-testrunner/src/testcase/xpath.rs
+++ b/xee-testrunner/src/testcase/xpath.rs
@@ -141,7 +141,7 @@ impl Runnable<XPathLanguage> for XPathTestCase {
 
         // now construct the dynamic context. We want to have one here
         // explicitly so we can use it later in the assertions
-        let mut builder = query.dynamic_context_builder(run_context.documents);
+        let mut builder = query.dynamic_context_builder();
         if let Some(context_item) = context_item {
             builder.context_item(context_item);
         }
@@ -170,9 +170,10 @@ impl Runnable<XPathLanguage> for XPathTestCase {
             }
         }
 
-        let context = builder.build();
-        // now execute the query with the right dynamic context
-        let result = query.execute_with_context(run_context.documents, &context);
+        let result = query.execute_with_builder(run_context.documents, &builder);
+
+        let mut dummy_docs = xee_xpath::Documents::new();
+        let context = builder.build(dummy_docs.documents());
 
         self.test_case.result.assert_result(
             &context,
@@ -196,10 +197,10 @@ impl ContextLoadable<LoadContext> for XPathTestCase {
     fn load_with_context(queries: &Queries, context: &LoadContext) -> Result<impl Query<Self>> {
         let test_query = queries.one("test/string()", convert_string)?;
         let test_case_query = TestCase::load_with_context(queries, context)?;
-        let test_case_query = test_case_query.map(move |test_case, documents, context| {
+        let test_case_query = test_case_query.map(move |test_case, documents, builder| {
             Ok(XPathTestCase {
                 test_case,
-                test: test_query.execute_with_context(documents, context)?,
+                test: test_query.execute_with_builder(documents, builder)?,
             })
         });
         Ok(test_case_query)

--- a/xee-testrunner/src/testcase/xslt.rs
+++ b/xee-testrunner/src/testcase/xslt.rs
@@ -136,12 +136,12 @@ impl Runnable<XsltLanguage> for XsltTestCase {
         if let Some(context_item) = context_item {
             builder.context_item(context_item);
         }
-        builder.documents(run_context.documents.documents().clone());
         // builder.variables(variables.clone());
         builder.current_datetime(chrono::offset::Utc::now().into());
-        let context = builder.build();
-        let runnable = program.runnable(&context);
-        let result = runnable.many(run_context.documents.xot_mut());
+        let result = run_context.documents.execute_program(&program, &builder);
+
+        let mut dummy_docs = xee_xpath::Documents::new();
+        let context = builder.build(dummy_docs.documents());
 
         self.test_case.result.assert_result(
             &context,

--- a/xee-xpath/src/documents.rs
+++ b/xee-xpath/src/documents.rs
@@ -1,7 +1,7 @@
 use iri_string::types::IriStr;
 use xee_interpreter::{
     context::DocumentsRef,
-    xml::{DocumentHandle, DocumentsError},
+    xml::{DocumentHandle, DocumentsError, Documents as XmlDocuments},
 };
 use xot::Xot;
 
@@ -25,10 +25,10 @@ use xot::Xot;
 pub struct Documents {
     // The Xot arena holding all nodes of the documents in the collection.
     pub(crate) xot: Xot,
-    // A reference to the underlaying collection of XML documents
-    // so they can be looked up by URI or handle. Each Document stores the
-    // URI and root node of the XML data.
-    pub(crate) documents: DocumentsRef,
+    // The underlaying collection of XML documents so they can be looked 
+    // up by URI or handle. Each Document stores the URI and root node
+    // of the XML data.
+    pub(crate) documents: XmlDocuments,
 }
 
 impl Documents {
@@ -36,7 +36,7 @@ impl Documents {
     pub fn new() -> Self {
         Self {
             xot: Xot::new(),
-            documents: DocumentsRef::new(),
+            documents: XmlDocuments::new(),
         }
     }
 
@@ -50,7 +50,6 @@ impl Documents {
         xml: &str,
     ) -> Result<DocumentHandle, DocumentsError> {
         self.documents
-            .borrow_mut()
             .add_string(&mut self.xot, Some(uri), xml)
     }
 
@@ -60,18 +59,30 @@ impl Documents {
     /// a [`xot::Error`].
     pub fn add_string_without_uri(&mut self, xml: &str) -> Result<DocumentHandle, DocumentsError> {
         self.documents
-            .borrow_mut()
             .add_string(&mut self.xot, None, xml)
+    }
+
+    /// Load a string as an XML document with an optional URI.
+    ///
+    /// Something may go wrong during processing of the XML document; this is
+    /// a [`xot::Error`].
+    pub fn add_string_with_optional_uri(
+        &mut self,
+        uri: Option<&IriStr>,
+        xml: &str,
+    ) -> Result<DocumentHandle, DocumentsError> {
+        self.documents
+            .add_string(&mut self.xot, uri, xml)
     }
 
     /// Given a handle give back the document node
     pub fn document_node(&self, handle: DocumentHandle) -> Option<xot::Node> {
-        self.documents.borrow().get_node_by_handle(handle)
+        self.documents.get_node_by_handle(handle)
     }
 
     /// Get a reference to the documents ([`xee_interpreter::xml::Documents`])
-    pub fn documents(&self) -> &DocumentsRef {
-        &self.documents
+    pub fn documents(&mut self) -> DocumentsRef<'_> {
+        DocumentsRef(std::cell::RefCell::new(&mut self.documents))
     }
 
     /// Get a reference to the Xot arena
@@ -82,6 +93,17 @@ impl Documents {
     /// Get a mutable reference to the Xot arena
     pub fn xot_mut(&mut self) -> &mut Xot {
         &mut self.xot
+    }
+
+    /// Execute a program with the given dynamic context builder.
+    pub fn execute_program(
+        &mut self,
+        program: &xee_interpreter::interpreter::Program,
+        builder: &xee_interpreter::context::DynamicContextBuilder,
+    ) -> Result<xee_interpreter::sequence::Sequence, xee_interpreter::error::SpannedError> {
+        let context = builder.build(DocumentsRef(std::cell::RefCell::new(&mut self.documents)));
+        let runnable = program.runnable(&context);
+        runnable.many(&mut self.xot)
     }
 }
 

--- a/xee-xpath/src/itemable.rs
+++ b/xee-xpath/src/itemable.rs
@@ -22,8 +22,7 @@ impl Itemable for xot::Node {
 impl Itemable for DocumentHandle {
     fn to_item(&self, documents: &Documents) -> Result<Item> {
         // TODO: This unwrap is not great; we should turn this into an error
-        let documents_ref = documents.documents.borrow();
-        let document = documents_ref.get_by_handle(*self).unwrap();
+        let document = documents.documents.get_by_handle(*self).unwrap();
         Ok(Item::Node(document.root()))
     }
 }

--- a/xee-xpath/src/query.rs
+++ b/xee-xpath/src/query.rs
@@ -27,24 +27,22 @@ pub trait Query<V> {
         self.program().static_context()
     }
 
-    /// Execute the query against a dynamic context
+    /// Execute the query against a dynamic context builder
     ///
     /// You can construct one using a [`DynamicContextBuilder`]
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
-        documents: &mut Documents,
-        context: &context::DynamicContext,
+        document: &mut Documents,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<V>;
 
     /// Get a dynamic context builder for the query, configured with the
-    /// query's static context and the document's documents.
+    /// query's static context.
     ///
     /// You can use this if you want to construct your own dynamic context
-    /// to use with `execute_with_context`.
-    fn dynamic_context_builder(&self, documents: &Documents) -> context::DynamicContextBuilder<'_> {
-        let mut context = self.program().dynamic_context_builder();
-        context.documents(documents.documents().clone());
-        context
+    /// to use with `execute_with_builder`.
+    fn dynamic_context_builder(&self) -> context::DynamicContextBuilder<'_> {
+        self.program().dynamic_context_builder()
     }
 
     /// Map the the result of the query to a different type.
@@ -54,7 +52,7 @@ pub trait Query<V> {
     fn map<T, F>(self, f: F) -> MapQuery<V, T, Self, F>
     where
         Self: Sized,
-        F: Fn(V, &mut Documents, &context::DynamicContext) -> Result<T> + Clone,
+        F: Fn(V, &mut Documents, &context::DynamicContextBuilder) -> Result<T> + Clone,
     {
         MapQuery {
             query: self,
@@ -81,10 +79,9 @@ pub trait Query<V> {
         documents: &mut Documents,
         build: impl FnOnce(&mut context::DynamicContextBuilder),
     ) -> Result<V> {
-        let mut dynamic_context_builder = self.dynamic_context_builder(documents);
+        let mut dynamic_context_builder = self.dynamic_context_builder();
         build(&mut dynamic_context_builder);
-        let context = dynamic_context_builder.build();
-        self.execute_with_context(documents, &context)
+        self.execute_with_builder(documents, &dynamic_context_builder)
     }
 }
 
@@ -104,22 +101,20 @@ pub trait RecurseQuery<C, V> {
     ///
     /// To do the conversion pass in a [`Recurse`] object. This
     /// allows you to use a convert function recursively.
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<C>;
 
     /// Get a dynamic context builder for the query, configured with the
-    /// query's static context and the document's documents.
+    /// query's static context.
     ///
     /// You can use this if you want to construct your own dynamic context
-    /// to use with `execute_with_context`.
-    fn dynamic_context_builder(&self, document: &Documents) -> context::DynamicContextBuilder<'_> {
-        let mut context = self.program().dynamic_context_builder();
-        context.documents(document.documents.clone());
-        context
+    /// to use with `execute_with_builder`.
+    fn dynamic_context_builder(&self) -> context::DynamicContextBuilder<'_> {
+        self.program().dynamic_context_builder()
     }
 
     /// Execute the query against an itemable.
@@ -142,10 +137,9 @@ pub trait RecurseQuery<C, V> {
         recurse: &Recurse<V>,
         build: impl FnOnce(&mut context::DynamicContextBuilder),
     ) -> Result<C> {
-        let mut dynamic_context_builder = self.dynamic_context_builder(document);
+        let mut dynamic_context_builder = self.dynamic_context_builder();
         build(&mut dynamic_context_builder);
-        let context = dynamic_context_builder.build();
-        self.execute_with_context(document, &context, recurse)
+        self.execute_with_builder(document, &dynamic_context_builder, recurse)
     }
 }
 
@@ -208,13 +202,16 @@ where
     F: Convert<V>,
 {
     /// Execute the query against a context
-    pub fn execute_with_context(
+    pub fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<V> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let item = sequence.one()?;
+        let item = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.one()?
+        };
         (self.convert)(document, &item)
     }
 }
@@ -227,12 +224,12 @@ where
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<V> {
-        OneQuery::execute_with_context(self, document, context)
+        OneQuery::execute_with_builder(self, document, builder)
     }
 }
 
@@ -247,14 +244,17 @@ impl OneRecurseQuery {
     ///
     /// To do the conversion pass in a [`Recurse`] object. This
     /// allows you to use a convert function recursively.
-    pub fn execute_with_context<V>(
+    pub fn execute_with_builder<V>(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<V> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let item = sequence.one()?;
+        let item = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.one()?
+        };
         recurse.execute(document, &item)
     }
 }
@@ -264,13 +264,13 @@ impl<V> RecurseQuery<V, V> for OneRecurseQuery {
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<V> {
-        OneRecurseQuery::execute_with_context(self, document, context, recurse)
+        OneRecurseQuery::execute_with_builder(self, document, builder, recurse)
     }
 }
 
@@ -301,13 +301,16 @@ where
 {
     /// Execute the query against an itemable, with explicit
     /// dynamic context.
-    pub fn execute_with_context(
+    pub fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Option<V>> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let item = sequence.option()?;
+        let item = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.option()?
+        };
         item.map(|item| (self.convert)(document, &item)).transpose()
     }
 }
@@ -320,12 +323,12 @@ where
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Option<V>> {
-        Self::execute_with_context(self, document, context)
+        Self::execute_with_builder(self, document, builder)
     }
 }
 
@@ -337,14 +340,17 @@ pub struct OptionRecurseQuery {
 
 impl OptionRecurseQuery {
     /// Execute the recursive query against an explicit dynamic context.
-    pub fn execute_with_context<V>(
+    pub fn execute_with_builder<V>(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<Option<V>> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let item = sequence.option()?;
+        let item = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.option()?
+        };
         item.map(|item| recurse.execute(document, &item))
             .transpose()
     }
@@ -355,13 +361,13 @@ impl<V> RecurseQuery<Option<V>, V> for OptionRecurseQuery {
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<Option<V>> {
-        OptionRecurseQuery::execute_with_context(self, document, context, recurse)
+        OptionRecurseQuery::execute_with_builder(self, document, builder, recurse)
     }
 }
 
@@ -389,17 +395,20 @@ impl<V, F> ManyQuery<V, F>
 where
     F: Convert<V>,
 {
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Vec<V>> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let items = sequence
-            .iter()
+        let items = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.iter().collect::<Vec<_>>()
+        };
+        items
+            .into_iter()
             .map(|item| (self.convert)(document, &item))
-            .collect::<Result<Vec<V>>>()?;
-        Ok(items)
+            .collect::<Result<Vec<V>>>()
     }
 }
 
@@ -411,12 +420,12 @@ where
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Vec<V>> {
-        Self::execute_with_context(self, document, context)
+        Self::execute_with_builder(self, document, builder)
     }
 }
 
@@ -431,18 +440,21 @@ impl ManyRecurseQuery {
     ///
     /// To do the conversion pass in a [`Recurse`] object. This
     /// allows you to use a convert function recursively.
-    pub fn execute_with_context<V>(
+    pub fn execute_with_builder<V>(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<Vec<V>> {
-        let sequence = self.program.runnable(context).many(document.xot_mut())?;
-        let items = sequence
-            .iter()
+        let items = {
+            let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+            let sequence = self.program.runnable(&context).many(&mut document.xot)?;
+            sequence.iter().collect::<Vec<_>>()
+        };
+        items
+            .into_iter()
             .map(|item| recurse.execute(document, &item))
-            .collect::<Result<Vec<V>>>()?;
-        Ok(items)
+            .collect::<Result<Vec<V>>>()
     }
 }
 
@@ -451,13 +463,13 @@ impl<V> RecurseQuery<Vec<V>, V> for ManyRecurseQuery {
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
         recurse: &Recurse<V>,
     ) -> Result<Vec<V>> {
-        ManyRecurseQuery::execute_with_context(self, document, context, recurse)
+        ManyRecurseQuery::execute_with_builder(self, document, builder, recurse)
     }
 }
 
@@ -477,12 +489,13 @@ pub struct SequenceQuery {
 
 impl SequenceQuery {
     /// Execute the query against an itemable with an explict dynamic context.
-    pub fn execute_with_context(
+    pub fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Sequence> {
-        self.program.runnable(context).many(document.xot_mut())
+        let context = builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut document.documents)));
+        self.program.runnable(&context).many(&mut document.xot)
     }
 }
 
@@ -491,12 +504,12 @@ impl Query<Sequence> for SequenceQuery {
         &self.program
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<Sequence> {
-        Self::execute_with_context(self, document, context)
+        Self::execute_with_builder(self, document, builder)
     }
 }
 
@@ -504,7 +517,7 @@ impl Query<Sequence> for SequenceQuery {
 #[derive(Debug, Clone)]
 pub struct MapQuery<V, T, Q: Query<V> + Sized, F>
 where
-    F: Fn(V, &mut Documents, &context::DynamicContext) -> Result<T> + Clone,
+    F: Fn(V, &mut Documents, &context::DynamicContextBuilder) -> Result<T> + Clone,
 {
     query: Q,
     f: F,
@@ -515,42 +528,40 @@ where
 impl<V, T, Q, F> MapQuery<V, T, Q, F>
 where
     Q: Query<V> + Sized,
-    F: Fn(V, &mut Documents, &context::DynamicContext) -> Result<T> + Clone,
+    F: Fn(V, &mut Documents, &context::DynamicContextBuilder) -> Result<T> + Clone,
 {
     /// Execute the query against an item.
     pub fn execute(&self, document: &mut Documents, item: &Item) -> Result<T> {
         let mut dynamic_context_builder = self.query.program().dynamic_context_builder();
         dynamic_context_builder.context_item(item.clone());
-        let context = dynamic_context_builder.build();
-        self.execute_with_context(document, &context)
+        self.execute_with_builder(document, &dynamic_context_builder)
     }
 
     /// Execute the query against a dynamic context.
-    pub fn execute_with_context(
+    pub fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<T> {
-        let v = self.query.execute_with_context(document, context)?;
-        // TODO: this isn't right. need to rewrite in terms of dynamic context too?
-        (self.f)(v, document, context)
+        let v = self.query.execute_with_builder(document, builder)?;
+        (self.f)(v, document, builder)
     }
 }
 
 impl<V, T, Q: Query<V> + Sized, F> Query<T> for MapQuery<V, T, Q, F>
 where
-    F: Fn(V, &mut Documents, &context::DynamicContext) -> Result<T> + Clone,
+    F: Fn(V, &mut Documents, &context::DynamicContextBuilder) -> Result<T> + Clone,
 {
     fn program(&self) -> &Program {
         self.query.program()
     }
 
-    fn execute_with_context(
+    fn execute_with_builder(
         &self,
         document: &mut Documents,
-        context: &context::DynamicContext,
+        builder: &context::DynamicContextBuilder,
     ) -> Result<T> {
-        let v = self.query.execute_with_context(document, context)?;
-        (self.f)(v, document, context)
+        let v = self.query.execute_with_builder(document, builder)?;
+        (self.f)(v, document, builder)
     }
 }

--- a/xee-xslt-ast/src/staticeval.rs
+++ b/xee-xslt-ast/src/staticeval.rs
@@ -232,7 +232,8 @@ impl StaticEvaluator {
         // TODO doing the clone here of the global variables isn't ideal
         dynamic_context_builder.variables(self.static_global_variables.clone());
 
-        let dynamic_context = dynamic_context_builder.build();
+        let mut docs = xee_xpath_compiler::xml::Documents::new();
+        let dynamic_context = dynamic_context_builder.build(xee_xpath_compiler::context::DocumentsRef(std::cell::RefCell::new(&mut docs)));
         let runnable = program.runnable(&dynamic_context);
 
         runnable.many(xot)

--- a/xee-xslt-compiler/src/run.rs
+++ b/xee-xslt-compiler/src/run.rs
@@ -18,8 +18,7 @@ pub fn evaluate_program(
     let root = documents.get_node_by_handle(handle).unwrap();
     let mut dynamic_context_builder = program.dynamic_context_builder();
     dynamic_context_builder.context_node(root);
-    dynamic_context_builder.documents(documents);
-    let context = dynamic_context_builder.build();
+    let context = dynamic_context_builder.build(xee_interpreter::context::DocumentsRef(std::cell::RefCell::new(&mut documents)));
     let runnable = program.runnable(&context);
     runnable.many(xot)
 }

--- a/xee/src/repl.rs
+++ b/xee/src/repl.rs
@@ -110,13 +110,13 @@ impl RunContext {
                 return Ok(());
             }
         };
-        let mut context_builder = sequence_query.dynamic_context_builder(&self.documents);
+        let mut context_builder = sequence_query.dynamic_context_builder();
         if let Some(doc) = self.document_handle {
             context_builder.context_item(doc.to_item(&self.documents)?);
         }
-        let context = context_builder.build();
+        
 
-        let sequence = sequence_query.execute_with_context(&mut self.documents, &context);
+        let sequence = sequence_query.execute_with_builder(&mut self.documents, &context_builder);
         let sequence = match sequence {
             Ok(sequence) => sequence,
             Err(e) => {
@@ -124,6 +124,8 @@ impl RunContext {
                 return Ok(());
             }
         };
+        let mut dummy_docs = Documents::new();
+        let context = context_builder.build(dummy_docs.documents());
         println!(
             "{}",
             sequence.display_representation(self.documents.xot(), &context)

--- a/xee/src/xpath.rs
+++ b/xee/src/xpath.rs
@@ -56,13 +56,13 @@ pub(crate) fn execute_query(
             return Ok(());
         }
     };
-    let mut context_builder = sequence_query.dynamic_context_builder(documents);
+    let mut context_builder = sequence_query.dynamic_context_builder();
     if let Some(doc) = doc {
         context_builder.context_item(doc.to_item(documents)?);
     }
-    let context = context_builder.build();
+    
 
-    let sequence = sequence_query.execute_with_context(documents, &context);
+    let sequence = sequence_query.execute_with_builder(documents, &context_builder);
     let sequence = match sequence {
         Ok(sequence) => sequence,
         Err(e) => {
@@ -70,6 +70,8 @@ pub(crate) fn execute_query(
             return Ok(());
         }
     };
+    let mut dummy_docs = xee_xpath::Documents::new();
+    let context = context_builder.build(dummy_docs.documents());
     println!(
         "{}",
         sequence.display_representation(documents.xot(), &context)


### PR DESCRIPTION
The purpose of this is to allow sharing an `xee_xpath::documents::Documents` object across threads, so it can be queried and interacted with. This approach has some key differences from #138 that we will discuss.

The problem is that `Documents` contains a `DocumentsRef`, which is neither `Send` nor `Sync`. This pr replaces that `DocumentsRef` for a plain `xee_interpreter::xml::Documents`, and changes the `DocumentsRef` from an `Rc<RefCell<xml::Documents>>` into a simpler `RefCell<&'a mut xml::Documents>`. This allows us to "create" a `DocumentsRef` when it's time to pass it to the interpreter, and drop it soon after (which can't be done with `Rc`s), and tracking it's lifetime across the interpreter instead of relying on reference counting.

A consequence of this is that when you take a reference to the `xml::Documents` out of `Documents` it has a lifetime and is borrowchecked (e.g. mutably accessing `Documents` would invalidate the reference), so we had to make a small change to the API. We replaced `Query::execute_with_context gets` with `Query::execute_with_builder`, this way, the full context (with the `xml::Documents` reference) is only built when executing, and the builder doesn't need lifetime tracking.

Due to the size of this project, I had the help of AI for the grunt work of the implementation. However, every change has been checked and most of them are just adding lifetimes to signatures. `cargo test` passes all tests, and `xee-testrunner` passes and fails the same tests as before the PR.

### Difference from #138

In #138, the `DocumentsRef` is made shareable between threads by replacing `Rc<RefCell<xml::Documents>>` with `Arc<RwLock<xml::Documents>>`. This leaves the API unchanged because it doesn't affects lifetimes, but has some major drawbacks:
* Performance
	* While `Arc` is almost free, `RwLock` is not, I haven't tested but it's sure to have some impact on performance because the interpreter locks and unlocks it repeatedly instead of only at the start and end of execution.
* Correctness
	* Now that `DocumentsRef` can be shared among threads, the compiler will allow running queries concurrently as long as you provide the `Xot` and the `DynamicContext`. But opening and closing the locks immediately only prevent the actual writes to overstep each other, but does not protect the two executions as a whole
* Thread safety
	* Other than correctness, the interpreter was not designed with that in mind, so there's an high risk of deadlocks if multiple queries are run at the same time